### PR TITLE
Wrap titles in plotly.js pie charts

### DIFF
--- a/dist/html.js
+++ b/dist/html.js
@@ -181,10 +181,13 @@ const plotData_${i} = [{
   textinfo: "label+percent",
   insidetextorientation: "radial"
 }];
+/* Plotly lets long titles overflow the container; wrap titles at max 60 chars */
+const wrappedTitle_${i} = "${pieChart.title}".replace(/([\\w\\s]{60,}?)\\s?\\b/g, "$1<br>");
+console.log(wrappedTitle_${i})
 Plotly.newPlot(
   'piechart_${i}', 
   plotData_${i},
-  {height: 399, width: 399, title: {text: '${pieChart.title}', font: {size: 10}}},
+  {height: 399, width: 399, title: {text: wrappedTitle_${i}, font: {size: 10}}},
   {staticPlot: true}
 );`;
 const html = async data => {

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -266,10 +266,12 @@ const plotData_${i} = [{
   textinfo: "label+percent",
   insidetextorientation: "radial"
 }];
+/* Plotly lets long titles overflow the container; wrap titles at max 60 chars */
+const wrappedTitle_${i} = "${pieChart.title}".replace(/([\\w\\s]{60,}?)\\s?\\b/g, "$1<br>");
 Plotly.newPlot(
   'piechart_${i}', 
   plotData_${i},
-  {height: 399, width: 399, title: {text: '${pieChart.title}', font: {size: 10}}},
+  {height: 399, width: 399, title: {text: wrappedTitle_${i}, font: {size: 10}}},
   {staticPlot: true}
 );`;
 


### PR DESCRIPTION
Before:

![Screen Shot 2024-03-13 at 17 43 35](https://github.com/AIObjectives/tttc-light-js/assets/1048995/1305c149-944c-44bd-b484-f366683a75b3)

After:

![Screen Shot 2024-03-13 at 17 43 38](https://github.com/AIObjectives/tttc-light-js/assets/1048995/811070a0-cab2-469a-b2e5-2e212a6f251e)

@Onurbon I'm going to go ahead and merge this into main so we can get back to Evan, just putting it on your radar