### PR TITLE
support Claude  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .DS_Store
 google-credentials.json
 .env*
+.vscode/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ export OPENAI_API_KEY=sk-something-something
 export OPENAI_API_KEY_PASSWORD=some-password
 ```
 
+Likewise for Claude:
+
+```
+export ANTHROPIC_API_KEY=sk-something-something
+export ANTHROPIC_API_KEY_PASSWORD=some-password
+```
+
 If a team member has already set up a Google Cloud Storage project, add the keys for that project to the same `.env` file. Otheriwse,
 see the "Setting up a Google Cloud instance" section for how to set up a project.
 
@@ -71,33 +78,33 @@ export type SourceRow = {
   timestamp?: string; // timestamp in the video
 };
 ```
+
 ## Provided client
 
 Open `localhost:8080/` to see the example of client provided.
 The client is written in plain html/css/js in the `public` folder.
-
 
 ## Setting up a Google Cloud instance
 
 ### Set up Google Cloud storage & services
 
 First create a new storage bucket:
+
 - Create a Google Cloud project and a Google Cloud Storage bucket
 - Add `GCLOUD_STORAGE_BUCKET=name-of-your-bucket` to your `.env`
 - Make sure this bucket has public access so that anyone can read from it (to
-make your reports accessible from your browser):
-    - Turn off the "Prevent public access" protect
-    - In the "Permissions" tab, click "Grant access." Add the principal `allUsers`
-      and assign the role `Storage Object User`.
+  make your reports accessible from your browser): - Turn off the "Prevent public access" protect - In the "Permissions" tab, click "Grant access." Add the principal `allUsers`
+  and assign the role `Storage Object User`.
 
 Then create a service account for this bucket:
+
 - In the "IAM & Admin" view, select "Service Accounts" from the left menu, and
   then click "Create service account"
 - Give this account the "Editor" role
 - Create keys for this account and download them as a json file:
-    - Save this file as `./google-credentials.json`
-    - Encode this using by running the command `base64 -i ./google-credentials.json`
-    - Put this in a variable `GOOGLE_CREDENTIALS_ENCODED` in your `.env`
+  - Save this file as `./google-credentials.json`
+  - Encode this using by running the command `base64 -i ./google-credentials.json`
+  - Put this in a variable `GOOGLE_CREDENTIALS_ENCODED` in your `.env`
 
 Your .env file should now look like this:
 
@@ -134,12 +141,12 @@ Note: the first deploy with fail if you haven't set the .env variables as descri
 Your cloud instance is now ready to use!
 
 To upload a new image (e.g. after a fresh git pull), deploy a new docker image to the same instance:
+
 - Run `./bin/docker-build-gcloud.sh`
 - Open the google console and search for gloud cloud run
 - Find your project and the `tttc-light-js` app
 - Click "EDIT AND DEPLOY NEW VERSION"
 - Find the new docker image that you just pushed from the list of available images
-
 
 ## Using docker locally (not recommended)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.20.2",
         "@google-cloud/storage": "^7.7.0",
         "axios": "^1.6.7",
         "cors": "^2.8.5",
@@ -49,6 +50,48 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.20.2.tgz",
+      "integrity": "sha512-5fk7Z8+crodNuARdOAU8rW16iAEIXdiYkv7D+Yjwt2TkhGfHpAQoOm9MwZkzqXMCmnnPgrKh1yz6O7uhpygwfQ==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
+      "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.20.2",
     "@google-cloud/storage": "^7.7.0",
     "axios": "^1.6.7",
     "cors": "^2.8.5",

--- a/src/gpt.ts
+++ b/src/gpt.ts
@@ -2,14 +2,6 @@ import OpenAI from "openai";
 
 import { Tracker, Cache } from "./types";
 
-export const testGPT = async (apiKey: string) => {
-  const openai = new OpenAI({ apiKey });
-  await openai.chat.completions.create({
-    messages: [{ role: "user", content: "hi" }],
-    model: "gpt-4-turbo-preview",
-  });
-};
-
 export const gpt = async (
   apiKey: string,
   cacheKey: string,

--- a/src/gpt.ts
+++ b/src/gpt.ts
@@ -1,8 +1,10 @@
 import OpenAI from "openai";
+import Anthropic from "@anthropic-ai/sdk";
 
 import { Tracker, Cache } from "./types";
 
 export const gpt = async (
+  model: String,
   apiKey: string,
   cacheKey: string,
   system: string,
@@ -10,30 +12,63 @@ export const gpt = async (
   tracker: Tracker,
   cache?: Cache
 ) => {
-  const openai = new OpenAI({ apiKey });
   if (cache && cache.get(cacheKey)) return cache.get(cacheKey);
   const start = Date.now();
-  const completion = await openai.chat.completions.create({
-    messages: [
-      { role: "system", content: system },
-      { role: "user", content: user },
-    ],
-    model: "gpt-4-turbo-preview",
-    response_format: { type: "json_object" },
-  });
-  const { prompt_tokens, completion_tokens } = completion.usage!;
+
+  let message: string;
+  let finish_reason: string;
+  let prompt_tokens: number;
+  let completion_tokens: number;
+
+  // OPENAI GPT
+  if (model.startsWith("gpt")) {
+    const openai = new OpenAI({ apiKey });
+    const completion = await openai.chat.completions.create({
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+      model: model as any,
+      ...(model.startsWith("gpt-4-turbo")
+        ? { response_format: { type: "json_object" } }
+        : {}),
+    });
+    prompt_tokens = completion.usage!.prompt_tokens;
+    completion_tokens = completion.usage!.completion_tokens;
+    finish_reason = completion.choices[0].finish_reason;
+    message = completion.choices[0].message.content!;
+  }
+
+  // ANTHROPIC CLAUDE
+  else if (model.startsWith("claude")) {
+    const anthropic = new Anthropic({ apiKey });
+    const completion = await anthropic.messages.create({
+      model: model as any,
+      system,
+      max_tokens: 1024,
+      messages: [{ role: "user", content: user }],
+    });
+    prompt_tokens = completion.usage.input_tokens;
+    completion_tokens = completion.usage.output_tokens;
+    finish_reason = completion.stop_reason || "stop";
+    message = completion.content[0].text;
+  }
+
+  // not supporting other models yet
+  else {
+    throw new Error(`Unknown model: ${model}`);
+  }
+
   const cost =
     prompt_tokens * (10 / 1000000) + completion_tokens * (30 / 1000000);
   tracker.costs += cost;
   tracker.prompt_tokens += prompt_tokens;
   tracker.completion_tokens += completion_tokens;
-  const { finish_reason, message } = completion.choices[0];
   if (finish_reason !== "stop") {
-    console.log(completion);
     console.log(message);
-    throw new Error("gpt 4 turbo stopped early!");
+    throw new Error("the AI stopped early!");
   } else {
-    const result = JSON.parse(message.content!);
+    const result = JSON.parse(message);
     if (cache) cache.set(cacheKey, result);
     const _s = ((Date.now() - start) / 1000).toFixed(1);
     const _c = cost.toFixed(2);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -17,6 +17,7 @@ import {
 } from "./types";
 
 const defaultOptions = {
+  model: "gpt-4-turbo-preview",
   data: [],
   title: "",
   question: "",
@@ -86,6 +87,7 @@ async function pipeline(
   console.log("Step 1: generating taxonomy of topics and subtopics");
 
   const { taxonomy }: { taxonomy: Taxonomy } = await gpt(
+    options.model,
     options.apiKey!,
     "taxonomy",
     systemMessage(options),
@@ -101,6 +103,7 @@ async function pipeline(
     await Promise.all(
       batch.map(async ({ id, comment }) => {
         const { claims } = await gpt(
+          options.model,
           options.apiKey!,
           "claims_from_" + id,
           systemMessage(options),
@@ -150,6 +153,7 @@ async function pipeline(
   for (const topic of taxonomy) {
     for (const subtopic of topic.subtopics) {
       const { nesting } = await gpt(
+        options.model,
         options.apiKey!,
         "nesting_" +
           subtopic.subtopicName

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,12 +33,15 @@ app.post("/generate", async (req, res) => {
       throw new Error("Missing data");
     }
     config.data = formatData(config.data);
+    // allow users to use our keys if they provided the password
     if (config.apiKey === process.env.OPENAI_API_KEY_PASSWORD) {
-      // allow users to use our keys if they provided the password
       config.apiKey = process.env.OPENAI_API_KEY!;
+    } else if (config.apiKey === process.env.ANTHROPIC_API_KEY_PASSWORD) {
+      config.apiKey = process.env.ANTHROPIC_API_KEY!;
     }
+
     if (!config.apiKey) {
-      throw new Error("Missing OpenAI API key");
+      throw new Error("Missing API key");
     }
     config.filename = config.filename || uniqueSlug(config.title);
     const url = getUrl(config.filename);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,8 @@
-import 'dotenv/config'
+import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import pipeline from "./pipeline";
 import html from "./html";
-import { testGPT } from "./gpt";
 import { Options } from "./types";
 import { getUrl, storeHtml } from "./storage";
 import { uniqueSlug, formatData, placeholderFile } from "./utils";
@@ -25,7 +24,7 @@ app.post("/generate", async (req, res) => {
         config.googleSheet.url,
         config.googleSheet.pieChartColumns,
         config.googleSheet.filterEmails,
-        config.googleSheet.oneSubmissionPerEmail,
+        config.googleSheet.oneSubmissionPerEmail
       );
       config.data = formatData(data);
       config.pieCharts = pieCharts;
@@ -41,7 +40,6 @@ app.post("/generate", async (req, res) => {
     if (!config.apiKey) {
       throw new Error("Missing OpenAI API key");
     }
-    await testGPT(config.apiKey); // will fail is key is invalid
     config.filename = config.filename || uniqueSlug(config.title);
     const url = getUrl(config.filename);
     await storeHtml(config.filename, placeholderFile());

--- a/src/test.ts
+++ b/src/test.ts
@@ -38,6 +38,7 @@ async function main() {
   const data = await loadSource();
   const json = await pipeline(
     {
+      model: "claudeclaude-3-opus-20240229",
       apiKey: process.env.OPENAI_API_KEY!,
       data,
       pieCharts: [

--- a/src/test.ts
+++ b/src/test.ts
@@ -38,7 +38,7 @@ async function main() {
   const data = await loadSource();
   const json = await pipeline(
     {
-      model: "claudeclaude-3-opus-20240229",
+      model: "claude-3-opus-20240229",
       apiKey: process.env.OPENAI_API_KEY!,
       data,
       pieCharts: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type PieChart = {
 };
 
 export type Options = {
+  model?: string;
   apiKey?: string;
   data?: SourceRow[];
   title: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type Options = {
     url: string;
     pieChartColumns?: string[];
     filterEmails?: string[];
+    oneSubmissionPerEmail?: boolean;
   };
 };
 


### PR DESCRIPTION
@colleenm I haven't tested this yet as I'm waiting to get an anthropic key. 

Overview: 
- I added a new option field `model`
- if `model` starts with `"gpt-"` we use OpenAI's API
- if `model` starts with `"claude-"` we use Anthropic's API
- default model remains gpt-4-turbo 