### PR TITLE
first pass local pyserver

### DIFF
--- a/pyserver/config.py
+++ b/pyserver/config.py
@@ -1,0 +1,82 @@
+#! usr/bin/env python
+
+# cheapest for testing 
+MODEL = "gpt-4o-mini" # prod default: "gpt-4-turbo-preview"
+
+SYSTEM_PROMPT = """
+You are a professional research assistant. You have helped run many public consultations,
+surveys and citizen assemblies. You have good instincts when it comes to extracting interesting insights.
+You are familiar with public consultation tools like Pol.is and you understand the benefits
+for working with very clear, concise claims that other people would be able to vote on.
+"""
+
+COMMENT_TO_TREE_PROMPT = """
+I will give you a list of comments.
+Please propose a way to organize the information contained in these comments into topics and subtopics of interest.
+Keep the topic and subtopic names very concise and use the short description to explain what the topic is about.
+
+Return a JSON object of the form {
+  "taxonomy": [
+    {
+      "topicName": string,
+      "topicShortDescription": string,
+      "subtopics": [
+        {
+          "subtopicName": string,
+          "subtopicShortDescription": string,
+        },
+        ...
+      ]
+    },
+    ...
+  ]
+}
+Now here is the list of comments:
+"""
+
+COMMENT_TO_CLAIMS_PROMPT = """
+I'm going to give you a comment made by a participant and a list of topics and subtopics which have already been extracted.
+I want you to extract a list of concise claims that the participant may support.
+We are only interested in claims that can be mapped to one of the given topic and subtopic.
+The claim must be fairly general but not a platitude.
+It must be something that other people may potentially disagree with. Each claim must also be atomic.
+For each claim, please also provide a relevant quote from the transcript.
+The quote must be as concise as possible while still supporting the argument.
+The quote doesn't need to be a logical argument.
+It could also be a personal story or anecdote illustrating why the interviewee would make this claim.
+You may use "[...]" in the quote to skip the less interesting bits of the quote.
+/return a JSON object of the form {
+  "claims": [
+    {
+      "claim": string, // a very concise extracted claim
+      "quote": string // the exact quote,
+      "topicName": string // from the given list of topics
+      "subtopicName": string // from the list of subtopics
+    },
+    // ...
+  ]
+}
+
+Now here is the list of topics/subtopics:"""
+# also include in prompt:
+# append ${taxonomy}
+# comments: And then here is the comment:"""
+
+CLAIM_DEDUP_PROMPT = """
+I'm going to give you a JSON object containing a list of claims with some ids.
+I want you to remove any near-duplicate claims from the list by nesting some claims under some top-level claims.
+For example, if we have 5 claims and claim 3 and 5 are similar to claim 2, we will nest claim 3 and 5 under claim 2.
+The nesting will be represented as a JSON object where the keys are the ids of the
+top-level claims and the values are lists of ids of the nested claims.
+
+Return a JSON object of the form {
+  "nesting": {
+    "claimId1": [],
+    "claimId2": ["claimId3", "claimId5"],
+    "claimId4": []
+  }
+}
+
+And now, here are the claims:"""
+
+WANDB_PROJECT_NAME = "t3c_llm_tree"

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -234,8 +234,8 @@ def dedup_claims(claims:list)-> dict:
 #####################################
 # Step 3: Sort & deduplicate claims #
 #-----------------------------------#
-@app.put("/sorted_claims/")
-def sort_claim_tree(claims_tree:ClaimTree, sort_type : str = "deduplicate", log_to_wandb: bool = False)-> dict:
+@app.put("/sort_claims_tree/")
+def sort_claims_tree(claims_tree:ClaimTree, sort_type : str = "deduplicate", log_to_wandb: bool = False)-> dict:
   #TODO: do we ever want to deduplicate without sorting? or sort without deduplicating?
   TK_IN = 0
   TK_OUT = 0
@@ -351,7 +351,7 @@ def test_claims():
   print(response.json())
 
 def test_dupes():
-  response = client.put("/sorted_claims/?log_to_wandb=True", json={"tree" : dupe_claims_4o})
+  response = client.put("/sort_claims_tree/?log_to_wandb=True", json={"tree" : dupe_claims_4o})
   print(response.json())
 
 # TODO: uncomment to test :)

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import json
+from openai import OpenAI
+from pydantic import BaseModel
+from typing import List, Union
+import wandb
+
+import pyserver.config as config
+from pyserver.utils import cute_print
+
+class Comment(BaseModel):
+  text: str
+
+class CommentList(BaseModel):
+  comments: List[Comment]
+
+class CommentTopicTree(BaseModel):
+  tree: dict
+  comments: List[Comment]
+
+class ClaimTree(BaseModel):
+  tree: dict 
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+  # TODO: setup/relevant defaults?
+  return {"Hello": "World"}
+
+###################################
+# Step 1: Comments to Topic Tree  #
+#---------------------------------#
+@app.post("/topic_tree/")
+def comments_to_tree(comments: CommentList, log_to_wandb:bool = False):
+  """
+  Given the full list of comments, return the tree of topics and subtopics
+  """
+  client = OpenAI()
+
+  # append comments to prompt
+  full_prompt = config.COMMENT_TO_TREE_PROMPT
+  for comment in comments.comments:
+    full_prompt += "\n" + comment.text
+
+  response = client.chat.completions.create(
+    model=config.MODEL,
+    messages=[
+      {
+        "role": "system",
+        "content": config.SYSTEM_PROMPT
+      },
+      {
+        "role": "user",
+        "content": full_prompt
+      }
+    ],
+    temperature = 0.0,
+    response_format = {"type": "json_object"}
+  )
+  try:
+    tree = json.loads(response.choices[0].message.content)
+  except:
+    # TODO: return an error?
+    tree = {}
+  usage = response.usage
+    
+  if log_to_wandb:
+    # TODO: one pipeline run should be one run — perhaps a group?
+    wandb.init(project = config.WANDB_PROJECT_NAME,
+               config={"model" : config.MODEL})
+
+    comment_lengths = [len(c.text) for c in comments.comments]
+    num_topics = len(tree["taxonomy"])
+    subtopic_bins = [len(t["subtopics"]) for t in tree["taxonomy"]]
+
+    # in case comments are empty / for W&B Table logging
+    comment_list = "none"
+    if len(comments.comments) > 1:
+      comment_list = "\n".join([c.text for c in comments.comments])
+    comms_tree_list = [[comment_list, json.dumps(tree,indent=1)]]
+
+    wandb.log({
+        "comm_N" : len(comments.comments),
+        "comm_text_len": sum(comment_lengths),
+        "comm_bins" : comment_lengths,
+        "num_topics" : num_topics,
+        "num_subtopics" : sum(subtopic_bins),
+        "subtopic_bins" : subtopic_bins,
+        "rows_to_tree" : wandb.Table(data=comms_tree_list,
+                                     columns = ["comments", "taxonomy"]),
+
+        # token counts
+        "u/1/N_tok": usage.total_tokens,
+        "u/1/in_tok" : usage.prompt_tokens,
+        "u/1/out_tok": usage.completion_tokens
+    })
+
+  return {"tree" : tree, "usage" : usage}
+
+def comment_to_claims(comment:str, tree:dict)-> dict:
+  """
+  Given a comment and the topic tree, extract one or more claims from the comment.
+  Place each claim under the correct subtopic in the tree
+  """
+  client = OpenAI()
+
+  # add taxonomy and comment to prompt template
+  full_prompt = config.COMMENT_TO_CLAIMS_PROMPT
+  taxonomy_string = json.dumps(tree)
+   
+  # TODO: prompt nit, shorten this to just "Comment:"
+  full_prompt += "\n" + taxonomy_string + "\nAnd then here is the comment:\n" + comment
+
+  response = client.chat.completions.create(
+    model = config.MODEL,
+    messages = [
+      {
+        "role": "system",
+        "content": config.SYSTEM_PROMPT
+      },
+      {
+            "role": "user",
+            "content": full_prompt
+      }
+    ],
+    temperature = 0.0,
+    response_format = {"type": "json_object"}
+  )
+  claims = response.choices[0].message.content
+  return {"claims" : json.loads(claims), "usage" : response.usage}
+
+####################################
+# Step 2: Extract and place claims #
+#----------------------------------#
+@app.post("/claims/")
+def all_comments_to_claims(tree:CommentTopicTree, log_to_wandb:bool = False) -> dict:
+  comms_to_claims = []
+  comms_to_claims_html = []
+  TK_2_IN = 0
+  TK_2_OUT = 0
+  TK_2_TOT = 0
+
+  node_counts = {}
+
+  # TODO: batch this so we're not sending the tree each time
+  for comment in tree.comments: 
+    response = comment_to_claims(comment.text, tree.tree)
+    claims = response["claims"]
+    # reference format
+    #{'claims': [{'claim': 'Dogs are superior pets.', 'quote': 'dogs are great', 'topicName': 'Pets', 'subtopicName': 'Dogs'}]} 
+    usage = response["usage"]
+    if claims and len(claims["claims"]) > 0:
+      comms_to_claims.extend([c for c in claims["claims"]])
+
+    TK_2_IN += usage.prompt_tokens
+    TK_2_OUT += usage.completion_tokens
+    TK_2_TOT += usage.total_tokens
+
+    # format for logging to W&B
+    if log_to_wandb:
+      viz_claims = cute_print(claims)
+      comms_to_claims_html.append([comment.text, viz_claims])  
+
+  # reference format
+  #[{'claim': 'Cats are the best household pets.', 'quote': 'I love cats', 'topicName': 'Pets', 'subtopicName': 'Cats'}, {'claim': 'Dogs are superior pets.', 'quote': 'dogs are great', 'topicName': 'Pets', 'subtopicName': 'Dogs'}, {'claim': 'Birds are not suitable pets for everyone.', 'quote': "I'm not sure about birds.", 'topicName': 'Pets', 'subtopicName': 'Birds'}]
+ 
+  # count the claims in each subtopic 
+  for claim in comms_to_claims:
+    if "topicName" in claim:
+      if claim["topicName"] in node_counts:
+        node_counts[claim["topicName"]]["total"] += 1
+        if "subtopicName" in claim:
+          if claim["subtopicName"] in node_counts[claim["topicName"]]["subtopics"]:
+            node_counts[claim["topicName"]]["subtopics"][claim["subtopicName"]]["total"] += 1
+            node_counts[claim["topicName"]]["subtopics"][claim["subtopicName"]]["claims"].append(claim["claim"])
+          else:
+            node_counts[claim["topicName"]]["subtopics"][claim["subtopicName"]] = { "total" : 1, "claims" : [claim["claim"]]}
+      else:
+        node_counts[claim["topicName"]] = {"total" : 1, "subtopics" : {claim["subtopicName"] : {"total" : 1, "claims" : [claim["claim"]]}}}
+
+
+  if log_to_wandb:
+    wandb.init(project = config.WANDB_PROJECT_NAME,
+               config={"model" : config.MODEL})
+    wandb.log({
+      "u/2/N_tok" : TK_2_TOT,
+      "u/2/in_tok": TK_2_IN,
+      "u/2/out_tok" : TK_2_OUT,
+      "rows_to_claims" : wandb.Table(
+                           data=comms_to_claims_html,
+                           columns = ["comments", "claims"])
+    })
+ 
+  net_usage = {"total_tokens" : TK_2_TOT,
+               "prompt_tokens" : TK_2_IN,
+               "completion_tokens" : TK_2_OUT}
+
+
+  return {"claims_tree" : node_counts, "usage" : net_usage}
+
+def dedup_claims(claims:list)-> dict:
+  """
+  Given a list of claims for a given subtopic, identify which ones are near-duplicates
+  """
+  client = OpenAI()
+
+  # add claims with enumerated ids (relative to this subtopic only)
+  full_prompt = config.CLAIM_DEDUP_PROMPT
+  for i, orig_claim in enumerate(claims):
+    full_prompt += "\nclaimId"+str(i)+ ": " + orig_claim
+
+  response = client.chat.completions.create(
+    model = config.MODEL,
+    messages = [
+      {
+        "role": "system",
+        "content": config.SYSTEM_PROMPT
+      },
+      {
+            "role": "user",
+            "content": full_prompt
+      }
+    ],
+    temperature = 0.0,
+    response_format = {"type": "json_object"}
+  )
+  deduped_claims = response.choices[0].message.content
+  return {"dedup_claims" : json.loads(deduped_claims), "usage" : response.usage}
+
+#####################################
+# Step 3: Sort & deduplicate claims #
+#-----------------------------------#
+@app.put("/sorted_claims/")
+def sort_claim_tree(claims_tree:ClaimTree, sort_type : str = "deduplicate", log_to_wandb: bool = False)-> dict:
+  #TODO: do we ever want to deduplicate without sorting? or sort without deduplicating?
+  TK_IN = 0
+  TK_OUT = 0
+  TK_TOT = 0
+  
+  dupe_counts = {}
+  dupe_logs = []
+  nested_claims = {}
+
+  if sort_type == "deduplicate": 
+    for topic, topic_data in claims_tree.tree.items():
+      for subtopic, subtopic_data in topic_data["subtopics"].items():
+        # no need to deduplicate single claims
+        if subtopic_data["total"] > 1:
+          response = dedup_claims(subtopic_data["claims"])
+          deduped_claims = response["dedup_claims"]
+          usage = response["usage"]
+
+          # check for duplicates
+          has_dupes = False
+          if "nesting" in deduped_claims:
+            for claim_key, claim_vals in deduped_claims["nesting"].items():
+              if len(claim_vals) > 0:
+                has_dupes = True
+                # extract relative index
+                claim_id = int(claim_key.split("Id")[1])
+                dupe_keys = [int(dupe_claim_key.split("Id")[1]) for dupe_claim_key in claim_vals]
+                dupe_counts[subtopic_data["claims"][claim_id]] = dupe_keys
+
+          # for logging to wandb
+          if log_to_wandb:
+            dupe_logs.append(["\n".join(subtopic_data["claims"]), json.dumps(deduped_claims, indent=1)])
+
+          if has_dupes:
+            nested_claims[subtopic] = {"dupes" : deduped_claims, "og" : subtopic_data["claims"]}
+
+          TK_TOT += usage.total_tokens
+          TK_IN += usage.prompt_tokens
+          TK_OUT += usage.completion_tokens
+  
+  # after counting any duplicates, sort the entire tree so more frequent topics appear first,
+  # more frequent subtopics appear first within each topic, 
+  # and claims with the most supporting quotes (including duplicates) appear first within each subtopic 
+  sorted_tree = {}
+  for topic, topic_data in claims_tree.tree.items():
+    topic_total = 0
+    topic_list = {}
+    for subtopic, subtopic_data in topic_data["subtopics"].items():
+      topic_total += subtopic_data["total"]
+      if subtopic in nested_claims:
+        # this one has some dupes
+        # for each duplicate claim, we list the duplicate ids
+        # but we don't currently merge them as "similar claims"
+        rerank = {}
+        for c in subtopic_data["claims"]:
+          if c in dupe_counts:
+            new_label = c + " (" + str(len(dupe_counts[c]) + 1) + "x:"
+            for ckey in dupe_counts[c]:
+              new_label += " " + str(ckey) + ","
+            new_label += ")"
+            rerank[new_label] = len(dupe_counts[c])
+          else:
+            rerank[c] = 0
+
+        # sort the most-duplicated to the top
+        ranked = sorted(rerank.items(), key=lambda x: x[1], reverse=True)
+        new_claims = [r[0] for r in ranked]
+        topic_list[subtopic] = {"total" : subtopic_data["total"], "claims" : new_claims}
+      else:
+        topic_list[subtopic] = {"total" : subtopic_data["total"], "claims" : subtopic_data["claims"]}
+
+    # sort subtopics themselves
+    sorted_topics = sorted(topic_list.items(), key=lambda x: x[1]["total"], reverse=True)
+
+    sorted_tree[topic] = {"total" : topic_total, "topics" : sorted_topics}
+
+  # sort full tree
+  full_sort_tree = sorted(sorted_tree.items(), key=lambda x: x[1]["total"], reverse=True)
+ 
+  if log_to_wandb:
+    wandb.init(project = config.WANDB_PROJECT_NAME,
+               config = {"model" : config.MODEL})
+    report_data = [[json.dumps(full_sort_tree, indent=2)]]
+    wandb.log({
+      "u/4/N_tok" : TK_TOT,
+      "u/4/in_tok": TK_IN,
+      "u/4/out_tok" : TK_OUT,
+      "dedup_subclaims" : wandb.Table(data=dupe_logs, columns = ["sub_claim_list", "deduped_claims"]),
+      "t3c_report" : wandb.Table(data=report_data, columns = ["t3c_report"])
+      # TODO: do we need this?
+      #"num_claims" : NUM_CLAIMS,
+      #"num_topics_post_sort" : NUM_TOPICS_STEP_3
+    })
+  return {"tree" : full_sort_tree, "per_topic_dupes" : nested_claims, "dupe_counts" : dupe_counts}
+
+#TODO: refactor into separate testing script
+
+######################
+# Testing the server #
+#--------------------#
+
+sample_tree_4o = {'tree': {'taxonomy': [{'topicName': 'Pets', 'topicShortDescription': 'General opinions about common household pets.', 'subtopics': [{'subtopicName': 'Cats', 'subtopicShortDescription': 'Positive sentiments towards cats.'}, {'subtopicName': 'Dogs', 'subtopicShortDescription': 'Positive sentiments towards dogs.'}, {'subtopicName': 'Birds', 'subtopicShortDescription': 'Uncertainty or mixed feelings about birds.'}]}]}, 'usage': {'completion_tokens': 125, 'prompt_tokens': 220, 'total_tokens': 345, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}}
+
+dupe_claims_4o = {'Pets': {'total': 5, 'subtopics': {'Cats': {'total': 2, 'claims': ['Cats are the best household pets.', 'Cats are superior pets compared to other animals.']}, 'Dogs': {'total': 2, 'claims': ['Dogs are superior pets compared to other animals.', 'Dogs are superior pets.']}, 'Birds': {'total': 1, 'claims': ['Birds are not suitable pets for everyone.']}}}}
+
+
+def test_topic_tree():
+  response = client.post("/topic_tree/?log_to_wandb=True", json={"comments" : [{"text" : "I love cats"},{"text" : "dogs are great"},{"text":"I'm not sure about birds"}]})
+  print(response.json())
+
+def test_claims():
+  response = client.post("/claims/?log_to_wandb=True", json={"comments" : [{"text" : "I love cats"}, {"text" : "dogs are great"}, {"text" : "dogs are excellent"}, {"text" : "Cats are cool"}, {"text": "I'm not sure about birds"}], "tree" : sample_tree_4o})
+  print(response.json())
+
+def test_dupes():
+  response = client.put("/sorted_claims/?log_to_wandb=True", json={"tree" : dupe_claims_4o})
+  print(response.json())
+
+# TODO: uncomment to test :)
+#client = TestClient(app)
+#test_topic_tree()
+#test_claims()
+#test_dupes()
+

--- a/pyserver/requirements.txt
+++ b/pyserver/requirements.txt
@@ -1,0 +1,5 @@
+fastapi[standard]
+json
+openai
+pydantic
+wandb

--- a/pyserver/test_oai.py
+++ b/pyserver/test_oai.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+# a super quick test of OpenAI calls
+
+from openai import OpenAI
+
+client = OpenAI()
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini"
+    messages=[
+        {
+            "role": "system",
+            "content": "You are a very wise wizard"
+        },
+        {
+            "role": "user",
+            "content": "What is the meaning of life?"
+        }
+        ],
+        temperature=0.0
+)
+tree = response.choices[0].message.content
+usage = response.usage
+print(tree)

--- a/pyserver/test_pipeline.py
+++ b/pyserver/test_pipeline.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+from fastapi.testclient import TestClient
+from .main import app
+
+#TODO: try a more principled way to test!
+
+client = TestClient(app)
+
+def test_topic_tree():
+    response = client.post("/topic_tree/", json={"comments" : [{"text" : "I love cats"},{"text" : "dogs are great"},{"text":"I'm not sure about birds"}]})
+    assert response.status_code == 200
+    #assert response.json() == {"name": "Foo", "price": 42}
+
+sample_tree_4o = {'tree': {'taxonomy': [{'topicName': 'Pets', 'topicShortDescription': 'General opinions about common household pets.', 'subtopics': [{'subtopicName': 'Cats', 'subtopicShortDescription': 'Positive sentiments towards cats.'}, {'subtopicName': 'Dogs', 'subtopicShortDescription': 'Positive sentiments towards dogs.'}, {'subtopicName': 'Birds', 'subtopicShortDescription': 'Uncertainty or mixed feelings about birds.'}]}]}, 'usage': {'completion_tokens': 125, 'prompt_tokens': 220, 'total_tokens': 345, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}}
+
+def test_claims():
+    response = client.post("/claims/?log_to_wandb=True", json={"comments" : [{"text" : "I love cats"}, {"text" : "dogs are great"}, {"text" : "dogs are excellent"}, {"text" : "Cats are cool"}, {"text": "I'm not sure about birds"}], "tree" : sample_tree_4o})
+    print(response.json())
+
+dupe_claims_4o = {'Pets': {'total': 5, 'subtopics': {'Cats': {'total': 2, 'claims': ['Cats are the best household pets.', 'Cats are superior pets compared to other animals.']}, 'Dogs': {'total': 2, 'claims': ['Dogs are superior pets compared to other animals.', 'Dogs are superior pets.']}, 'Birds': {'total': 1, 'claims': ['Birds are not suitable pets for everyone.']}}}}
+
+def test_dupes():
+  response = client.put("/sorted_claims/?log_to_wandb=True", json={"tree" : dupe_claims_4o})
+  print(response.json())
+

--- a/pyserver/utils.py
+++ b/pyserver/utils.py
@@ -1,0 +1,10 @@
+#! /usr/bin env python
+import json
+import wandb
+
+def cute_print(json_obj):
+  """Returns a pretty version of a dictionary as properly-indented and scaled
+  json in html for at-a-glance review in W&B"""
+  str_json = json.dumps(json_obj, indent=1)
+  cute_html = '<pre id="json"><font size=2>' + str_json + "</font></pre>"
+  return wandb.Html(cute_html)


### PR DESCRIPTION
adds a basic Python server for the T3C LLM pipeline:
* Step 1: **POST /topic_tree/** : given a list of comments [1] return a tree of topics and subtopics
* Step 2: **POST /claims/**: given a topic tree and one comment at a time [2], extract claims from each comment and return a topic tree with claims placed correctly (including original quote) 
* Step 3: **PUT /sort_claims_tree/**: given a tree with placed claims [3] deduplicate the claims in each subtopic and return a sorted version of the full tree, where most common topics, subtopics, and claims each appear first in their parent branch

TODOS

P0
- [ ] how do we call this properly from JS/FE?
- [ ] how do we package this to run a Python backend in prod?
- [ ] check for headers/cors/user authentication gotchas
- [ ] correctly set up & pass around OpenAI and wandb API keys, esp for any external users
- [ ] set up & test client overrides of prompts/models

P1
- [ ] more serious load-testing with larger CSV files
- [ ] preferred/best practice for HTTP/API param/request style & more robust error checking (e.g type/max length) on FastAPI routes/body/queries/etc

P2
- [ ] proper pytest setup
- [ ] add cost logging back in, or build cost calculation around wandb
- [ ] add Weave back in if we miss it more than once
- [ ] style/format for Python code :), black/poetry?

[1]: format/schema for comment list:
```
class Comment(BaseModel):
  text: str
class CommentList(BaseModel):
  comments: List[Comment]
```
[2] format/schema for topic tree with comments
```
class CommentTopicTree(BaseModel):
  tree: dict
  comments: List[Comment]
```
[3] format/schema for claims tree
```
class ClaimTree(BaseModel):
  tree: dict
```

