### PR TITLE
#49 << Remove json from requirements

### DIFF
--- a/pyserver/requirements.txt
+++ b/pyserver/requirements.txt
@@ -1,5 +1,4 @@
 fastapi[standard]
-json
 openai
 pydantic
 wandb


### PR DESCRIPTION
Merges into #49 

Removes json from list of requirements in pyserver. Was causing me an issue since the json module is native to python.