### PR TITLE
Pyserver pass API key

### DIFF
--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -12,6 +12,7 @@ const llmConfig = z.object(
     model_name: z.string(),
     system_prompt: z.string(),
     user_prompt: z.string(),
+    api_key: z.string(),
   },
   { invalid_type_error: "Invalid llmConfig" },
 );

--- a/express-server/src/pipeline/pipeline.test.ts
+++ b/express-server/src/pipeline/pipeline.test.ts
@@ -463,10 +463,11 @@ const testDedupTree: apiPyserver.SortClaimsTreeRequest["tree"] = {
   },
 };
 
-const makeLLMConfig = (user_prompt: string) => ({
+const makeLLMConfig = (user_prompt: string): apiPyserver.LLMConfig => ({
   system_prompt: defaultSystemPrompt,
   user_prompt,
   model_name: "gpt-4o-mini",
+  api_key: "INCLUDE_KEY_HERE",
 });
 
 /**
@@ -477,7 +478,10 @@ const makeLLMConfig = (user_prompt: string) => ({
  */
 
 // test topicTreePipelineStep with comment data
+// ! STALE
 describe.skip("topicTreePipelineStep", () => {
+  throw new Error("Test stale");
+  console.log(process.env["OPENAI_API_KEY"]);
   it("should return a topic tree", async () => {
     const body = {
       comments: testCommentData.comments,
@@ -493,7 +497,9 @@ describe.skip("topicTreePipelineStep", () => {
 });
 
 // test claimsPipelineStep with comment data and taxonomy data
+// ! STALE
 describe.skip("claimsPipelineStep", () => {
+  throw new Error("Test stale");
   it("should return a list of claims", async () => {
     const result = await claimsPipelineStep(env, {
       llm: makeLLMConfig(defaultExtractionPrompt),
@@ -507,7 +513,9 @@ describe.skip("claimsPipelineStep", () => {
 });
 
 // test sortClaimsTreePipelineStep with comment data and taxonomy data
+// ! STALE
 describe.skip("sortClaimsTreePipelineStep", () => {
+  throw new Error("Test stale");
   it("should return a sorted list of claims", async () => {
     const result = await sortClaimsTreePipelineStep(env, {
       tree: testDedupTree,

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -35,6 +35,7 @@ export const pipeLineWorker = new Worker(
       system_prompt: config.systemInstructions,
       user_prompt,
       model_name: config.model || "gpt-4o-mini",
+      api_key: config.apiKey,
     });
 
     const options: schema.OldOptions = { ...defaultConfig, ...config };

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -23,11 +23,11 @@ from typing import List, Union
 import wandb
 
 # TODO: which set of imports shall we keep? :)
-import config
-from utils import cute_print
+# import config
+# from utils import cute_print
 
-#import pyserver.config as config
-#from pyserver.utils import cute_print
+import pyserver.config as config
+from pyserver.utils import cute_print
 
 class Comment(BaseModel):
   id: str
@@ -40,6 +40,7 @@ class LLMConfig(BaseModel):
   model_name: str
   system_prompt: str
   user_prompt: str
+  api_key: str
  
 class CommentsLLMConfig(BaseModel):
   comments: List[Comment]   
@@ -50,8 +51,9 @@ class CommentTopicTree(BaseModel):
   llm: LLMConfig
   tree: dict
 
-class ClaimTree(BaseModel):
-  tree: dict 
+class ClaimTreeLLMConfig(BaseModel):
+  tree: dict
+  llm: LLMConfig
 
 app = FastAPI()
 
@@ -144,7 +146,10 @@ def comments_to_tree(req: CommentsLLMConfig, log_to_wandb:str = "") -> dict:
     }
   }
   """
-  client = OpenAI()
+  api_key = req.llm.api_key
+  client = OpenAI(
+    api_key=api_key
+  )
 
   # append comments to prompt
   full_prompt = req.llm.user_prompt
@@ -216,7 +221,10 @@ def comment_to_claims(llm:dict, comment:str, tree:dict)-> dict:
   """
   Given a comment and the full taxonomy/topic tree for the report, extract one or more claims from the comment.
   """
-  client = OpenAI()
+  api_key = llm.api_key
+  client = OpenAI(
+    api_key=api_key
+  )
 
   # add taxonomy and comment to prompt template
   taxonomy_string = json.dumps(tree)
@@ -439,11 +447,14 @@ def all_comments_to_claims(req:CommentTopicTree, log_to_wandb:str = "") -> dict:
 
   return {"data" : node_counts, "usage" : net_usage}
 
-def dedup_claims(claims:list)-> dict:
+def dedup_claims(claims:list, llm:LLMConfig)-> dict:
   """
   Given a list of claims for a given subtopic, identify which ones are near-duplicates
   """
-  client = OpenAI()
+  api_key = llm.api_key
+  client = OpenAI(
+    api_key=api_key
+  )
 
   # add claims with enumerated ids (relative to this subtopic only)
   full_prompt = config.CLAIM_DEDUP_PROMPT
@@ -476,7 +487,7 @@ def dedup_claims(claims:list)-> dict:
 # Step 3: Sort & deduplicate claims #
 #-----------------------------------#
 @app.put("/sort_claims_tree/")
-def sort_claims_tree(claims_tree:ClaimTree, log_to_wandb:str = "")-> dict:
+def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
   """
   Sort the topic/subtopic tree so that the most popular claims, subtopics, and topics
   all appear first. Deduplicate claims within each subtopic so that any near-duplicates appear as
@@ -655,13 +666,14 @@ def sort_claims_tree(claims_tree:ClaimTree, log_to_wandb:str = "")-> dict:
   DOES matter, or where we want to sum the claims by a particular speaker or by other metadata 
   towards the total for a subtopic/topic.
   """
-
+  claims_tree = req.tree
+  llm = req.llm
   TK_IN = 0
   TK_OUT = 0
   TK_TOT = 0
   dupe_logs = []
   sorted_tree = {} 
-  for topic, topic_data in claims_tree.tree.items():
+  for topic, topic_data in claims_tree.items():
     per_topic_total = 0
     per_topic_list = {}
     for subtopic, subtopic_data in topic_data["subtopics"].items():
@@ -670,7 +682,7 @@ def sort_claims_tree(claims_tree:ClaimTree, log_to_wandb:str = "")-> dict:
       # no need to deduplicate single claims
       if subtopic_data["total"] > 1:
         try:
-          response = dedup_claims(subtopic_data["claims"])
+          response = dedup_claims(subtopic_data["claims"], llm=llm)
         except:
           print("Step 3: no deduped claims response for: ", subtopic_data["claims"])
           continue


### PR DESCRIPTION
The pyserver api now takes an api key to use for ChatGPT. 

Changes the shape of the third route's parameters so it can take an llm config.

Did a successful full pipeline test, so it should be working.

@staceysv can you make sure your tests still work with this? Idk how you manage your tests and such.