### PR TITLE
Dev script now spins up venv for pyserver

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -13,7 +13,7 @@ const nextScript = `cd ${__dirname}/next-client && npm i && npm run dev`;
 const commonScript = `cd ${__dirname}/common && npm i && npm run build && npm run watch`;
 const expressScript = `cd ${__dirname}/express-server && npm i && npm run dev`;
 // const pyservScript = `cd ${__dirname}/pyserver && if [ ! -f "Pipfile" ]; then pipenv install -r requirements.txt; else pipenv install; fi && pipenv shell && fastapi dev main.py`
-const pyservScript = `cd ${__dirname}/pyserver && pipenv install -r requirements.txt && pipenv run fastapi dev main.py`;
+const pyservScript = `cd ${__dirname}/pyserver && source .venv/bin/activate && fastapi dev main.py`;
 const runScript = (script) =>
   child_process.exec(
     `osascript -e 'tell application \"Terminal\" to do script \"${script}\"'`,

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -210,7 +210,7 @@ def comments_to_tree(req: CommentsLLMConfig, log_to_wandb:str = "") -> dict:
       print("Failed to create wandb run")
   #NOTE:we could return a dictionary with one key "taxonomy", or the raw taxonomy list directly
   # choosing the latter for now 
-  return {"data" : tree["taxonomy"], "usage" : usage}
+  return {"data" : tree["taxonomy"], "usage" : usage.model_dump()}
 
 def comment_to_claims(llm:dict, comment:str, tree:dict)-> dict:
   """


### PR DESCRIPTION
When you run dev.js (`npm run dev` from root) it'll initialize the venv environment before starting the pyserver.

This also removes the automatic installation from requirements.txt. I thought about including it, but thought maybe there would be an issue with whether people use pip, pip3, or some other alias? Idk what the best approach for that would be. If you have any suggestions let me know. If we exclude it, we'll probably need to mention that in the README
