### PR TITLE
speaker attribution

### DIFF
--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -45,8 +45,9 @@ export type Usage = z.infer<typeof usage>;
  * Comments as consumed in the pyserver pipeline. Slightly different than schema.
  */
 const comment = z.object({
-  text: z.string().min(1, "Empty comment"),
   id: z.string(),
+  text: z.string().min(1, "Empty comment"),
+  speaker: z.string(),
 });
 
 /**

--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -132,16 +132,16 @@ const claimsWithDuplicates = z.object({
 
 const sortedSubtopic = z.object({
   counts: z.object({
-    claims : z.number(),
-    speakers: z.number()
+    claims: z.number(),
+    speakers: z.number(),
   }),
   topics: z
     .tuple([
       z.string(),
       z.object({
         counts: z.object({
-          claims : z.number(),
-          speakers: z.number()
+          claims: z.number(),
+          speakers: z.number(),
         }),
         claims: claimsWithDuplicates.array(),
       }),

--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -104,10 +104,7 @@ const claimsTree = z.record(z.string(), claimsTreeNode);
 
 export type ClaimsTree = z.infer<typeof claimsTree>;
 
-export const sortReportBy = z.enum([
-  "numPeople",
-  "numClaims",
-]);
+export const sortReportBy = z.enum(["numPeople", "numClaims"]);
 export type SortReportBy = z.infer<typeof sortReportBy>;
 
 /**

--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -73,6 +73,7 @@ const partialTopic = z.object({
 const baseClaim = z.object({
   claim: z.string(),
   quote: z.string(),
+  speaker: z.string(),
   topicName: z.string(),
   subtopicName: z.string(),
   commentId: z.string(),
@@ -109,6 +110,7 @@ export type ClaimsTree = z.infer<typeof claimsTree>;
 const dupedClaims = z.object({
   claim: z.string(),
   quote: z.string(),
+  speaker: z.string(),
   topicName: z.string(),
   subtopicName: z.string(),
   commentId: z.string(),
@@ -121,6 +123,7 @@ const dupedClaims = z.object({
 const claimsWithDuplicates = z.object({
   claim: z.string(),
   quote: z.string(),
+  speaker: z.string(),
   topicName: z.string(),
   subtopicName: z.string(),
   commentId: z.string(),

--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -104,6 +104,12 @@ const claimsTree = z.record(z.string(), claimsTreeNode);
 
 export type ClaimsTree = z.infer<typeof claimsTree>;
 
+export const sortReportBy = z.enum([
+  "numPeople",
+  "numClaims",
+]);
+export type SortReportBy = z.infer<typeof sortReportBy>;
+
 /**
  * Claims that are duplicates of another claim.
  */
@@ -195,6 +201,7 @@ export const claimsReply = z.object({
 export const sortClaimsTreeRequest = z.object({
   tree: claimsTree,
   llm: llmConfig,
+  sort: z.string(), //ReportBy: sortReportBy,
 });
 export type SortClaimsTreeRequest = z.infer<typeof sortClaimsTreeRequest>;
 

--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -104,9 +104,6 @@ const claimsTree = z.record(z.string(), claimsTreeNode);
 
 export type ClaimsTree = z.infer<typeof claimsTree>;
 
-export const sortReportBy = z.enum(["numPeople", "numClaims"]);
-export type SortReportBy = z.infer<typeof sortReportBy>;
-
 /**
  * Claims that are duplicates of another claim.
  */
@@ -134,12 +131,18 @@ const claimsWithDuplicates = z.object({
 });
 
 const sortedSubtopic = z.object({
-  total: z.number(),
+  counts: z.object({
+    claims : z.number(),
+    speakers: z.number()
+  }),
   topics: z
     .tuple([
       z.string(),
       z.object({
-        total: z.number(),
+        counts: z.object({
+          claims : z.number(),
+          speakers: z.number()
+        }),
         claims: claimsWithDuplicates.array(),
       }),
     ])
@@ -198,7 +201,7 @@ export const claimsReply = z.object({
 export const sortClaimsTreeRequest = z.object({
   tree: claimsTree,
   llm: llmConfig,
-  sort: z.string(), //ReportBy: sortReportBy,
+  sort: z.string(),
 });
 export type SortClaimsTreeRequest = z.infer<typeof sortClaimsTreeRequest>;
 

--- a/common/morphisms/index.ts
+++ b/common/morphisms/index.ts
@@ -1,2 +1,2 @@
-export * from "./morphisms";
+export * from "./tree-metrics";
 export { llmPipelineToSchema } from "./pipeline";

--- a/common/morphisms/morphisms.ts
+++ b/common/morphisms/morphisms.ts
@@ -5,10 +5,14 @@ import { z } from "zod";
 // TODO: Review this file - add comments and make more readble.
 
 const fromSources = (arg: schema.Source[]): string[] =>
-  Array.from(new Set(arg.map((src) => src.id)));
+  Array.from(
+    new Set(arg.map((src, i) => src.interview ?? `${Date.now()} #${i}`)),
+  );
 
 const fromReferences = (arg: schema.Referece[]): string[] =>
-  Array.from(new Set(arg.map((ref) => ref.id)));
+  Array.from(
+    new Set(arg.map((ref, i) => ref.interview ?? `${Date.now()} #${i}`)),
+  );
 
 const fromQuotes = (arg: schema.Quote[]): string[] =>
   fromReferences(arg.flatMap((claim) => claim.reference));

--- a/common/morphisms/pipeline.ts
+++ b/common/morphisms/pipeline.ts
@@ -33,6 +33,7 @@ const buildSourceMap = (sourceRows: schema.SourceRow[]) =>
   sourceRows.reduce((accum, curr) => {
     accum[curr.id!] = {
       id: uuid(),
+      interview: curr.interview,
       data: [
         "text",
         {

--- a/common/morphisms/pipeline.ts
+++ b/common/morphisms/pipeline.ts
@@ -34,7 +34,7 @@ const colorPicker = (idx: number) => colorArr[idx % colorArr.length];
 const makeAnonymousInterview = (sourceRows: schema.SourceRow[]) => {
   const usedAnonNums = sourceRows
     .map((r) => r.interview.match(/Anonymous #(\d+)/))
-    .map((expArr) => (expArr[0] ? parseInt(expArr[1]) : null))
+    .map((expArr) => (expArr ? parseInt(expArr[1]) : null))
     .filter((val) => val !== null)
     .map(Math.abs);
 

--- a/common/morphisms/tree-metrics.ts
+++ b/common/morphisms/tree-metrics.ts
@@ -79,7 +79,8 @@ export const getNPeople = (
     | schema.Source[],
 ) => chainReport(arg).length;
 
-export const getNClaims = (arg: schema.Subtopic[]) => fromSubtopics(arg).length;
+export const getNClaims = (arg: schema.Subtopic[]) =>
+  arg.flatMap((s) => s.claims).length;
 
 export const getQuotes = (claim: schema.Claim): schema.Quote[] =>
   claim.quotes.concat(claim.similarClaims.flatMap((clm) => clm.quotes));

--- a/common/schema.ts
+++ b/common/schema.ts
@@ -235,6 +235,7 @@ const mediaSources = z.union([
 
 export const source = z.object({
   id: z.string(),
+  interview: z.string().default("Anonymous"),
   data: mediaSources,
 });
 

--- a/common/schema.ts
+++ b/common/schema.ts
@@ -276,6 +276,7 @@ const referenceAudio = z.tuple([
 export const reference = z.object({
   id: z.string(),
   sourceId: z.string(),
+  interview: z.string().default("Anonymous"),
   data: z.union([referenceText, referenceVideo, referenceAudio]),
 });
 

--- a/common/schema.ts
+++ b/common/schema.ts
@@ -393,9 +393,27 @@ export const reportDataObj = z.object({
   questionAnswers: z.optional(questionAnswer.array()),
   topics: z.array(topic).transform((topics) =>
     topics.sort((a, b) => {
-      const claimsA = a.subtopics.flatMap((sub) => sub.claims);
-      const claimsB = b.subtopics.flatMap((sub) => sub.claims);
-      return claimsB.length - claimsA.length;
+      const setSpeakersA = new Set(
+        a.subtopics.flatMap((sub) =>
+          sub.claims.flatMap((c) =>
+            c.quotes.flatMap((q) => q.reference.interview),
+          ),
+        ),
+      );
+      const setSpeakersB = new Set(
+        new Set(
+          b.subtopics.flatMap((sub) =>
+            sub.claims.flatMap((c) =>
+              c.quotes.flatMap((q) => q.reference.interview),
+            ),
+          ),
+        ),
+      );
+      return setSpeakersB.size - setSpeakersA.size;
+      // leave this here for now until we start handling sorting by both.
+      // const claimsA = a.subtopics.flatMap((sub) => sub.claims);
+      // const claimsB = b.subtopics.flatMap((sub) => sub.claims);
+      // return claimsB.length - claimsA.length;
     }),
   ),
   sources: z.array(source),

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -108,7 +108,7 @@ const setupPipelineWorker = (connection: Redis) => {
       await job.updateProgress({
         status: api.reportJobStatus.Values.sorting,
       });
-      // TODO: more principled way of configuring this? 
+      // TODO: more principled way of configuring this?
       const numPeopleSort = "numPeople";
 
       const { data: tree } = await sortClaimsTreePipelineStep(env, {

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -108,13 +108,12 @@ const setupPipelineWorker = (connection: Redis) => {
       await job.updateProgress({
         status: api.reportJobStatus.Values.sorting,
       });
-
+      // TODO: more principled way of configuring this? 
       const numPeopleSort = "numPeople";
 
       const { data: tree } = await sortClaimsTreePipelineStep(env, {
         tree: claims_tree,
         llm: dedupLLMConfig,
-        //sortReportBy: "numPeople",
         sort: numPeopleSort,
       });
 

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -68,10 +68,19 @@ const setupPipelineWorker = (connection: Redis) => {
         completion_tokens: 0,
       };
 
-      const comments = options.data.map((x, i) => ({
-        text: x.comment,
-        id: x.id,
-      }));
+      const comments: { speaker: string; text: string; id: string }[] =
+        options.data.map((x) => ({
+          speaker: x.interview,
+          text: x.comment,
+          id: x.id,
+        }));
+      console.log("worker comments", comments);
+
+      if (comments.some((x) => !x.speaker)) {
+        throw new Error(
+          "Worker expects input data to include interview col to be filled out",
+        );
+      }
 
       console.log("Step 1: generating taxonomy of topics and subtopics");
       await job.updateProgress({

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -109,9 +109,13 @@ const setupPipelineWorker = (connection: Redis) => {
         status: api.reportJobStatus.Values.sorting,
       });
 
+      const numPeopleSort = "numPeople";
+
       const { data: tree } = await sortClaimsTreePipelineStep(env, {
         tree: claims_tree,
         llm: dedupLLMConfig,
+        //sortReportBy: "numPeople",
+        sort: numPeopleSort,
       });
 
       const newTax: schema.Taxonomy = taxonomy.map((t) => ({

--- a/next-client/src/app/about/page.tsx
+++ b/next-client/src/app/about/page.tsx
@@ -64,6 +64,7 @@ function Testimonial({ text }: { text: string | JSX.Element }) {
       <CardContent>
         <QuoteText
           text={text}
+          interview=""
           className="text-muted-foreground"
           iconClassName="fill-muted-foreground"
         />

--- a/next-client/src/components/claim/Claim.tsx
+++ b/next-client/src/components/claim/Claim.tsx
@@ -50,7 +50,13 @@ export function ClaimCard({ claim }: { claim: schema.Claim }) {
       <ClaimHeader variant="hovercard" claim={claim} />
       <Col gap={2}>
         {getQuotes(claim).map((quote) => (
-          <QuoteText key={quote.id} text={quote.text} />
+          <QuoteText
+            key={quote.id}
+            text={quote.text}
+            // Added parsing here since reports generated prior to this commit that use schema
+            // - do not get assigned a default interview tag
+            interview={schema.reference.parse(quote.reference).interview}
+          />
         ))}
       </Col>
     </Col>

--- a/next-client/src/components/quote/Quote.tsx
+++ b/next-client/src/components/quote/Quote.tsx
@@ -18,10 +18,12 @@ export function QuoteCard({ quote }: { quote: schema.Quote }) {
 
 export function QuoteText({
   text,
+  interview,
   className,
   iconClassName,
 }: {
   text: string | JSX.Element;
+  interview: string;
   className?: string;
   iconClassName?: string;
 }) {
@@ -32,7 +34,10 @@ export function QuoteText({
         <Icons.Quote className={cn("h-4 w-4 fill-black", iconClassName)} />
       </div>
       <div>
-        <p className={cn("", className)}>{text}</p>
+        <p className={cn("", className)}>
+          {text}
+          <span className="text-muted-foreground"> - {interview}</span>
+        </p>
       </div>
     </Row>
   );
@@ -41,7 +46,7 @@ export function QuoteText({
 export function Quote({ quote }: { quote: schema.Quote }) {
   return (
     <Row gap={3}>
-      <QuoteText text={quote.text} />
+      <QuoteText text={quote.text} interview={quote.reference.interview} />
       {/* Chevron */}
       <div className="h-full self-center flex-shrink-0">
         {/* ! leave this commented out for now */}

--- a/next-client/src/components/report/Report.tsx
+++ b/next-client/src/components/report/Report.tsx
@@ -245,8 +245,7 @@ export function ReportTitle({
       <Row gap={4} className="h-5">
         {/* Number of people */}
         <TextIcon icon={<Icons.People size={16} className="self-center" />}>
-          {/* {nPeople} people */} {/* ! temp removed for QA testing*/}
-          416 participants
+          {nPeople} people
         </TextIcon>
         {/* Date */}
         <TextIcon icon={<Icons.Date size={16} className="self-center" />}>

--- a/next-client/src/components/report/hooks/useReportState.ts
+++ b/next-client/src/components/report/hooks/useReportState.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { Dispatch, useReducer } from "react";
+import { getNPeople } from "tttc-common/morphisms";
 
 import * as schema from "tttc-common/schema";
 
@@ -388,7 +389,7 @@ const stateBuilder = (topics: schema.Topic[]): ReportState => ({
     .map(makeTopicNode)
     .sort(
       (a, b) =>
-        getNumberOfClaimsFromTopic(b.data) - getNumberOfClaimsFromTopic(a.data),
+        getNumberOfPeopleFromTopic(b.data) - getNumberOfPeopleFromTopic(a.data),
     ),
   focusedId: null,
 });
@@ -401,8 +402,8 @@ const makeTopicNode = (topic: schema.Topic): TopicNode => ({
     .map(makeSubSubtopicNode)
     .sort(
       (a, b) =>
-        getNumberOfClaimsFromSubtopic(b.data) -
-        getNumberOfClaimsFromSubtopic(a.data),
+        getNumberOfPeopleFromSubTopic(b.data) -
+        getNumberOfPeopleFromSubTopic(a.data),
     ),
 });
 
@@ -416,10 +417,16 @@ const makeClaimNode = (claim: schema.Claim): ClaimNode => ({
   data: claim,
 });
 
-const getNumberOfClaimsFromTopic = (topic: schema.Topic): number =>
-  topic.subtopics.flatMap((sub) => sub.claims).length;
-const getNumberOfClaimsFromSubtopic = (subtopic: schema.Subtopic): number =>
-  subtopic.claims.length;
+// const getNumberOfClaimsFromTopic = (topic: schema.Topic): number =>
+//   topic.subtopics.flatMap((sub) => sub.claims).length;
+// const getNumberOfClaimsFromSubtopic = (subtopic: schema.Subtopic): number =>
+//   subtopic.claims.length;
+
+const getNumberOfPeopleFromTopic = (topic: schema.Topic) =>
+  getNPeople(topic.subtopics);
+
+const getNumberOfPeopleFromSubTopic = (subtopic: schema.Subtopic) =>
+  getNPeople(subtopic.claims);
 
 //  ********************************
 //  * REDUCER *

--- a/next-client/src/components/subtopic/Subtopic.tsx
+++ b/next-client/src/components/subtopic/Subtopic.tsx
@@ -78,14 +78,12 @@ export function SubtopicDescription({ description }: { description: string }) {
 
 export function SubtopicSummary({ subtopic }: { subtopic: schema.Subtopic }) {
   const { title, claims, description } = subtopic;
-  // ! Temp change for QA testing
-  const nPeople = Math.floor(getNPeople(claims) * 0.45);
   return (
     <Col gap={4} className="px-4 sm:px-8">
       <SubtopicHeader
         title={title}
         numClaims={claims.length}
-        numPeople={nPeople}
+        numPeople={getNPeople(claims)}
         button={<CopyLinkButton anchor={title} />}
       />
       <PointGraphic claims={subtopic.claims} />

--- a/next-client/src/components/topic/Topic.tsx
+++ b/next-client/src/components/topic/Topic.tsx
@@ -98,8 +98,7 @@ export function TopicHeader({ button }: { button?: React.ReactNode }) {
           // </div>
         }
       >
-        {getNClaims(subtopics)} claims by {/* ! Temp change for QA testing */}
-        {Math.floor(getNPeople(subtopics) * 0.45)} people
+        {getNClaims(subtopics)} claims by {getNPeople(subtopics)} people
       </TextIcon>
       {button}
     </Row>

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -585,17 +585,26 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
     [
         "Pets",
         {
-            "total": 5,
+            "num_speakers" : 5,
+            "speakers" : [
+                "Alice",
+                "Bob",
+                "Charles",
+                "Dany",
+                "Elinor"
+            ],
+            "num_claims": 5,
             "topics": [
                 [
                     "Cats",
                     {
-                        "total": 2,
+                        "num_claims": 2,
                         "claims": [
                             {
                                 "claim": "Cats are the best pets.",
                                 "commentId":"c1",
                                 "quote": "I love cats.",
+                                "speaker" : "Alice",
                                 "topicName": "Pets",
                                 "subtopicName": "Cats",
                                 "duplicates": [
@@ -603,6 +612,7 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
                                         "claim": "Cats are the best pets.",
                                         "commendId:"c1"
                                         "quote": "I really really love cats",
+                                        "speaker" : "Elinor",
                                         "topicName": "Pets",
                                         "subtopicName": "Cats",
                                         "duplicated": true
@@ -610,17 +620,23 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
                                 ]
                             }
                         ]
+                        "num_speakers" : 2,
+                        "speakers" : [
+                            "Alice",
+                            "Elinor"
+                        ]
                     }
                 ],
                 [
                     "Birds",
                     {
-                        "total": 2,
+                        "num_claims": 2,
                         "claims": [
                             {
                                 "claim": "Birds are not ideal pets for everyone.",
                                 "commentId:"c3",
                                 "quote": "I'm not sure about birds.",
+                                "speaker" : "Charles",
                                 "topicName": "Pets",
                                 "subtopicName": "Birds",
                                 "duplicates": [
@@ -628,6 +644,7 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
                                         "claim": "Birds are not suitable pets for everyone.",
                                         "commentId" "c3",
                                         "quote": "I don't know about birds.",
+                                        "speaker": "Dany",
                                         "topicName": "Pets",
                                         "subtopicName": "Birds",
                                         "duplicated": true
@@ -635,21 +652,32 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
                                 ]
                             }
                         ]
+                        "num_speakers" : 2,
+                        "speakers" : [
+                            "Charles",
+                            "Dany"
+                        ]
                     }
                 ],
                 [
                     "Dogs",
                     {
-                        "total": 1,
+                        "num_claims": 1,
                         "claims": [
                             {
                                 "claim": "Dogs are superior pets.",
                                 "commentId": "c2",
                                 "quote": "dogs are great",
+                                "speaker" : "Bob",
                                 "topicName": "Pets",
                                 "subtopicName": "Dogs"
                             }
                         ]
+                        "num_speakers" : 1,
+                        "speakers" : [
+                            "Bob"
+                        ]
+                      
                     }
                 ]
             ]
@@ -786,7 +814,7 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
         per_topic_speakers.add(speaker)
         
       # add list of sorted, deduplicated claims to the right subtopic node in the tree
-      per_topic_list[subtopic] = {"total" : subtopic_data["total"], "claims" : sorted_deduped_claims, "speakers": per_topic_speakers}
+      per_topic_list[subtopic] = {"num_claims" : subtopic_data["total"], "claims" : sorted_deduped_claims, "num_people" : len(per_topic_speakers), "speakers": list(per_topic_speakers)}
 
     # sort all the subtopics in a given topic
     # two ways of sorting 1/16:
@@ -798,17 +826,17 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
     print("per topic speakers: ", set_topic_speakers)
 
     if req.sort == "numPeople":
-      sorted_subtopics = sorted(per_topic_list.items(), key=lambda x: len(x[1]["speakers"]), reverse=True)
+      sorted_subtopics = sorted(per_topic_list.items(), key=lambda x: x[1]["num_people"], reverse=True)
     elif req.sort == "numClaims":
-      sorted_subtopics = sorted(per_topic_list.items(), key=lambda x: x[1]["total"], reverse=True)
+      sorted_subtopics = sorted(per_topic_list.items(), key=lambda x: x[1]["num_claims"], reverse=True)
     # we have to add all the speakers
-    sorted_tree[topic] = {"total" : per_topic_total, "topics" : sorted_subtopics, "speakers" : set_topic_speakers}
+    sorted_tree[topic] = {"num_claims" : per_topic_total, "topics" : sorted_subtopics, "num_people" : len(set_topic_speakers), "speakers" : list(set_topic_speakers)}
 
   # sort all the topics in the tree
   if req.sort == "numPeople":
-    full_sort_tree = sorted(sorted_tree.items(), key=lambda x: len(x[1]["speakers"]), reverse=True)
+    full_sort_tree = sorted(sorted_tree.items(), key=lambda x: x[1]["num_people"], reverse=True)
   elif req.sort == "numClaims":
-    full_sort_tree = sorted(sorted_tree.items(), key=lambda x: x[1]["total"], reverse=True)
+    full_sort_tree = sorted(sorted_tree.items(), key=lambda x: x[1]["num_claims"], reverse=True)
  
   print(full_sort_tree)
   if log_to_wandb:

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -810,6 +810,7 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
   elif req.sort == "numClaims":
     full_sort_tree = sorted(sorted_tree.items(), key=lambda x: x[1]["total"], reverse=True)
  
+  print(full_sort_tree)
   if log_to_wandb:
     try:
       exp_group_name = str(log_to_wandb)

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -32,6 +32,7 @@ from pyserver.utils import cute_print
 class Comment(BaseModel):
   id: str
   text: str
+  speaker: str
 
 class CommentList(BaseModel):
   comments: List[Comment]
@@ -379,12 +380,12 @@ def all_comments_to_claims(req:CommentTopicTree, log_to_wandb:str = "") -> dict:
 
   node_counts = {}
   # TODO: batch this so we're not sending the tree each time
-  for comment in req.comments: 
+  for comment in req.comments:
     response = comment_to_claims(req.llm, comment.text, req.tree)
     try:
        claims = response["claims"]
        for claim in claims["claims"]:
-         claim.update({'commentId':comment.id})
+         claim.update({'commentId': comment.id, 'speaker' : comment.speaker})
     except:
       print("Step 2: no claims for comment: ", response)
       claims = None
@@ -443,7 +444,6 @@ def all_comments_to_claims(req:CommentTopicTree, log_to_wandb:str = "") -> dict:
   net_usage = {"total_tokens" : TK_2_TOT,
                "prompt_tokens" : TK_2_IN,
                "completion_tokens" : TK_2_OUT}
-
 
   return {"data" : node_counts, "usage" : net_usage}
 
@@ -673,6 +673,7 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = "")-> dict:
   TK_TOT = 0
   dupe_logs = []
   sorted_tree = {} 
+
   for topic, topic_data in claims_tree.items():
     per_topic_total = 0
     per_topic_list = {}

--- a/pyserver/test_pipeline.py
+++ b/pyserver/test_pipeline.py
@@ -21,7 +21,8 @@ longer_pets_15 = [{"id":"0", "text":"I love cats", "speaker" : "Alice"},{"id":"1
 
 topic_tree_4o = {"taxonomy" : [{'topicName': 'Pets', 'topicShortDescription': 'General opinions about common household pets.', 'subtopics': [{'subtopicName': 'Cats', 'subtopicShortDescription': 'Positive sentiments towards cats.'}, {'subtopicName': 'Dogs', 'subtopicShortDescription': 'Positive sentiments towards dogs.'}, {'subtopicName': 'Birds', 'subtopicShortDescription': 'Uncertainty or mixed feelings about birds.'}]}]}
 
-speaker_pets_3 = [{"id":"a", "text":"I love cats", "speaker" : "Alice"},{"id":"b", "text":"dogs are great", "speaker" : "Bob"},\
+speaker_pets_3 = [{"id":"a", "text":"I love cats", "speaker" : "Alice"},\
+                {"id":"b", "text":"dogs are great", "speaker" : "Bob"},\
                 {"id":"c","text":"I'm not sure about birds", "speaker" : "Charles"}]
             ##    {"id":"d","text":"I really really love cats"},{"id":"e","text":"I don't know about birds"}]
 
@@ -64,7 +65,7 @@ def test_claims(comments=dupes_pets_5):
 def test_dupes(claims_tree=dupe_claims_4o_speakers):
   llm = base_llm
   llm.update({"user_prompt" : config.CLAIM_DEDUP_PROMPT})
-  request ={"llm" : llm, "tree" : claims_tree, "sort" : "numClaims"}
+  request ={"llm" : llm, "tree" : claims_tree, "sort" : "numPeople"}
   response = client.put("/sort_claims_tree/", json=request)
   print(json.dumps(response.json(), indent=4))
 
@@ -86,9 +87,9 @@ def test_full_pipeline(comments=dupes_pets_5):
 
   print("\n\nStep 3: Dedup & sort\n\n")
   llm.update({"user_prompt" : config.CLAIM_DEDUP_PROMPT})
-  request ={"llm" : llm, "tree" : claims }
-  full_tree = client.put("/sort_claims_tree/", json=request).json()["data"]
-  json_print(full_tree)
+  request ={"llm" : llm, "tree" : claims , "sort" : "numPeople"}
+  full_tree = client.put("/sort_claims_tree/", json=request)
+  print(json.dumps(full_tree.json(), indent=4))
 
 #################
 # W&B log tests #

--- a/pyserver/test_pipeline.py
+++ b/pyserver/test_pipeline.py
@@ -149,7 +149,7 @@ client = TestClient(app)
 #test_topic_tree()
 #test_claims()
 #test_dupes()
-#test_full_pipeline(longer_pets_15)
+test_full_pipeline(longer_pets_15)
 
 #test_wb_topic_tree()
 #test_wb_claims()

--- a/pyserver/test_pipeline.py
+++ b/pyserver/test_pipeline.py
@@ -3,30 +3,41 @@ import json
 from fastapi.testclient import TestClient
 from main import app
 import config
+import os
 
 ##################
 # Sample inputs  #
 #----------------#
 
-min_pets_1 = [{"id":"1", "text":"I love cats"}]
+min_pets_1 = [{"id":"1", "text":"I love cats", "speaker" : "Alice"}]
 min_pets_3 = [{"id":"1", "text":"I love cats"},{"id":"2","text":"dogs are great"},{"id":"3","text":"I'm not sure about birds"}]
 dupes_pets_5 = [{"id":"a", "text":"I love cats"},{"id":"b", "text":"dogs are great"},{"id":"c","text":"I'm not sure about birds"},\
                 {"id":"d","text":"I really really love cats"},{"id":"e","text":"I don't know about birds"}]
-longer_pets_15 = [{"id":"0", "text":"I love cats"},{"id":"1","text":"I really really love dogs"},{"id":"2","text":"I'm not sure about birds"},\
-  {"id":"3","text" : "Cats are my favorite"},{"id":"4","text" : "Lizards are terrifying"}, {"id":"5", "text" : "Lizards are so friggin scary"},\
-  {"id":"6","text" : "Dogs are the best"}, {"id":"7","text":  "No seriously dogs are great"}, {"id":"8","text" : "Birds I'm hesitant about"},\
-  {"id":"9","text" : "I'm wild about cats"},{"id":"10","text" : "Dogs and cats are both adorable and fluffy"},{"id":"11","text" : "Good pets are chill"},
-  {"id":"12","text" :"Cats are fantastic"},{"id":"13","text" : "Lizards are gorgeous and I love them so much"},{"id":"14","text" : "Kittens are so boring"}]
+longer_pets_15 = [{"id":"0", "text":"I love cats", "speaker" : "Alice"},{"id":"1","text":"I really really love dogs", "speaker" : "Bob"},{"id":"2","text":"I'm not sure about birds", "speaker" : "Charles"},\
+  {"id":"3","text" : "Cats are my favorite", "speaker" : "Dany"},{"id":"4","text" : "Lizards are terrifying", "speaker" : "Alice"}, {"id":"5", "text" : "Lizards are so friggin scary", "speaker" : "Charles"},\
+  {"id":"6","text" : "Dogs are the best", "speaker" : "Elinor"}, {"id":"7","text":  "No seriously dogs are great", "speaker" : "Bob"}, {"id":"8","text" : "Birds I'm hesitant about", "speaker" : "Elinor"},\
+  {"id":"9","text" : "I'm wild about cats", "speaker" : "Gary"},{"id":"10","text" : "Dogs and cats are both adorable and fluffy", "speaker" : "Fiona"},{"id":"11","text" : "Good pets are chill", "speaker" : "Elinor"},
+  {"id":"12","text" :"Cats are fantastic", "speaker" : "Alice"},{"id":"13","text" : "Lizards are gorgeous and I love them so much", "speaker" : "Elinor"},{"id":"14","text" : "Kittens are so boring", "speaker" : "Fiona"}]
 
 topic_tree_4o = {"taxonomy" : [{'topicName': 'Pets', 'topicShortDescription': 'General opinions about common household pets.', 'subtopics': [{'subtopicName': 'Cats', 'subtopicShortDescription': 'Positive sentiments towards cats.'}, {'subtopicName': 'Dogs', 'subtopicShortDescription': 'Positive sentiments towards dogs.'}, {'subtopicName': 'Birds', 'subtopicShortDescription': 'Uncertainty or mixed feelings about birds.'}]}]}
 
+speaker_pets_3 = [{"id":"a", "text":"I love cats", "speaker" : "Alice"},{"id":"b", "text":"dogs are great", "speaker" : "Bob"},\
+                {"id":"c","text":"I'm not sure about birds", "speaker" : "Charles"}]
+            ##    {"id":"d","text":"I really really love cats"},{"id":"e","text":"I don't know about birds"}]
+
 # NOTE: gpt-4o-mini is cheaper/better for basic tests, but it fails on some very basic deduplication
+API_KEY = os.getenv('OPENAI_API_KEY')
 base_llm = {
   "model_name" : "gpt-4o-mini",
-  "system_prompt": config.SYSTEM_PROMPT
+  "system_prompt": config.SYSTEM_PROMPT,
+  "api_key" : API_KEY
 }
 
 dupe_claims_4o_ids = {'Pets': {'total': 5, 'subtopics': {'Cats': {'total': 2, 'claims': [{'claim': 'Cats are the best household pets.', 'quote': 'I love cats', 'topicName': 'Pets', 'subtopicName': 'Cats', 'commentId': 'a'}, {'claim': 'Cats are the best household pets.', 'quote': 'I really really love cats', 'topicName': 'Pets', 'subtopicName': 'Cats', 'commentId': 'd'}]}, 'Dogs': {'total': 1, 'claims': [{'claim': 'Dogs are superior pets.', 'quote': 'dogs are great', 'topicName': 'Pets', 'subtopicName': 'Dogs', 'commentId': 'b'}]}, 'Birds': {'total': 2, 'claims': [{'claim': 'Birds are not ideal pets for everyone.', 'quote': "I'm not sure about birds.", 'topicName': 'Pets', 'subtopicName': 'Birds', 'commentId': 'c'}, {'claim': 'There is uncertainty about birds as pets.', 'quote': "I don't know about birds.", 'topicName': 'Pets', 'subtopicName': 'Birds', 'commentId': 'e'}]}}}}
+
+dupe_claims_4o_speakers = {'Pets': {'total': 5, 'subtopics': {'Cats': {'total': 2, 'claims': [{'claim': 'Cats are the best household pets.', 'quote': 'I love cats', 'topicName': 'Pets', 'subtopicName': 'Cats', 'commentId': 'a', "speaker" : "Alice"}, {'claim': 'Cats are the best household pets.', 'quote': 'I really really love cats', 'topicName': 'Pets', 'subtopicName': 'Cats', 'commentId': 'd', "speaker" : "Dany"}]}, 'Dogs': {'total': 1, 'claims': [{'claim': 'Dogs are superior pets.', 'quote': 'dogs are great', 'topicName': 'Pets', 'subtopicName': 'Dogs', 'commentId': 'b', "speaker" : "Bob"}]}, 'Birds': {'total': 2, 'claims': [{'claim': 'Birds are not ideal pets for everyone.', 'quote': "I'm not sure about birds.", 'topicName': 'Pets', 'subtopicName': 'Birds', 'commentId': 'c', "speaker" : "Charles"}, {'claim': 'There is uncertainty about birds as pets.', 'quote': "I don't know about birds.", 'topicName': 'Pets', 'subtopicName': 'Birds', 'commentId': 'e', "speaker" : "Elinor"}]}}}}
+
+
 
 # maximize readability
 def json_print(json_obj):
@@ -36,24 +47,24 @@ def json_print(json_obj):
 # Basic tests #
 #-------------#
 
-def test_topic_tree():
+def test_topic_tree(comments=min_pets_3):
   llm = base_llm
   llm.update({"user_prompt" : config.COMMENT_TO_TREE_PROMPT})
-  request ={"llm" : llm, "comments" : min_pets_3}
+  request ={"llm" : llm, "comments" : comments}
   response = client.post("/topic_tree/", json=request)
   json_print(response.json())
 
-def test_claims():
+def test_claims(comments=dupes_pets_5):
   llm = base_llm
   llm.update({"user_prompt" : config.COMMENT_TO_CLAIMS_PROMPT})
-  request ={"llm" : llm, "comments" : dupes_pets_5, "tree" : topic_tree_4o}
+  request ={"llm" : llm, "comments" : comments, "tree" : topic_tree_4o}
   response = client.post("/claims/", json=request)
   print(json.dumps(response.json(), indent=4))
 
-def test_dupes():
+def test_dupes(claims_tree=dupe_claims_4o_speakers):
   llm = base_llm
   llm.update({"user_prompt" : config.CLAIM_DEDUP_PROMPT})
-  request ={"llm" : llm, "tree" : dupe_claims_4o_ids}
+  request ={"llm" : llm, "tree" : claims_tree, "sort" : "numClaims"}
   response = client.put("/sort_claims_tree/", json=request)
   print(json.dumps(response.json(), indent=4))
 
@@ -131,11 +142,13 @@ def test_wb_full_pipeline(comments=dupes_pets_5):
 # Run tests #
 #-----------#
 client = TestClient(app)
+#test_claims(longer_pets_15)
+#test_dupes()
 
-test_topic_tree()
-test_claims()
-test_dupes()
-test_full_pipeline(longer_pets_15)
+#test_topic_tree()
+#test_claims()
+#test_dupes()
+#test_full_pipeline(longer_pets_15)
 
 #test_wb_topic_tree()
 #test_wb_claims()


### PR DESCRIPTION
WIP Pyserver expects and tracks "speaker" for every comment

For sorting claims/third pipeline step
- accepts "sort" = ["numPeople" | "numClaims"]
- returns "num_claims" and "num_speakers", as well as the list of distinct "speakers", for every topic and subtopic

TODOs:
- [x] test end-to-end with local deploy
- [x] confirm TS integration / style
- [ ] think about timing of set() vs dict for very large participant numbers?