### PR TITLE
NextJS build uses tsconfig.build.json file now

### DIFF
--- a/next-client/next.config.js
+++ b/next-client/next.config.js
@@ -3,6 +3,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   /* config options here */
+  typescript: {
+    tsconfigPath: "tsconfig.build.json",
+  },
 };
 
 module.exports = nextConfig;

--- a/next-client/tsconfig.build.json
+++ b/next-client/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.*", "**/*.stories.tsx"]
+}


### PR DESCRIPTION
Updates NextJS build so that it uses tsconfig.build.json instead. This helps in case we run into any type errors in tests and stories, so it doesn't cause the whole thing to crash, and they aren't bundled. 

Making this a draft for now to not mess with current devops stuff. But let me know when it would be fine to merge it - it'll probably save devops some headache.