### PR TITLE
Report layout

### DIFF
--- a/next-client/src/components/barchart/Barchart.tsx
+++ b/next-client/src/components/barchart/Barchart.tsx
@@ -70,19 +70,15 @@ export function Bar({
 }) {
   if (percent > 1 || percent < 0)
     throw new Error("Barchart should only accept values between 0 and 1");
-  const divRef = useRef<HTMLDivElement>(null);
-
-  const [width, setWidth] = useState<number>(0);
 
   const fillColor = useThemeColor(color, "bg");
 
-  useLayoutEffect(() => {
-    setWidth((divRef.current?.offsetWidth || 0) * percent);
-  }, [divRef.current?.offsetWidth]);
-
   return (
-    <Row ref={divRef} className="flex-grow bg-secondary items-center">
-      <div className={`${fillColor} h-[2px]`} style={{ width: width }} />
+    <Row className="flex-grow bg-secondary items-center">
+      <div
+        className={`${fillColor} h-[2px]`}
+        style={{ width: `${percent * 100}%` }}
+      />
       <div className="bg-gray-300 h-[2px] flex-grow" />
     </Row>
   );

--- a/next-client/src/components/outline/Outline.tsx
+++ b/next-client/src/components/outline/Outline.tsx
@@ -135,7 +135,7 @@ function OutlineItem({
           className={`pl-${heirarchyDepth * 4} p2 select-none text-ellipsis w-[230px] overflow-hidden whitespace-nowrap items-center`}
           onClick={onBodyClick}
         >
-          {title + "adlfadlfjaldf"}
+          {title}
         </p>
         <OutlineCarrot
           onClick={onIconClick}

--- a/next-client/src/components/outline/Outline.tsx
+++ b/next-client/src/components/outline/Outline.tsx
@@ -53,7 +53,7 @@ function Outline({
 
   return (
     <OutlineContext.Provider value={{ dispatch }}>
-      <Col gap={2} className="h-full ">
+      <Col gap={2} className="h-full bg-primary-foreground">
         {/* Top icon */}
         <TextIcon icon={<Icons.Outline size={16} />} className="pl-5">
           Outline
@@ -117,7 +117,7 @@ function OutlineItem({
 }>) {
   return (
     // column here because opened nodes should continue the spacing.
-    <Col gap={outlineSpacing} className="max-w-[279px]">
+    <Col gap={outlineSpacing} className="max-w-[279px] bg-slate-300">
       <Row
         gap={2}
         className={`group items-center ${node.isHighlighted ? node.color : ""} ${node.hoverColor} cursor-pointer`}
@@ -132,9 +132,9 @@ function OutlineItem({
         {/* Nested items should be further to the right */}
         <Row
           gap={2}
-          className={`pl-${heirarchyDepth * 4} w-[230px] overflow-hidden whitespace-nowrap items-center justify-between flex-grow`}
+          className={`pl-${heirarchyDepth * 4} w-[230px] overflow-hidden whitespace-nowrap items-center justify-between`}
         >
-          <div onClick={onBodyClick} className="flex flex-grow">
+          <div onClick={onBodyClick} className="flex">
             <p className="p2 overflow-ellipsis overflow-hidden select-none">
               {title}
             </p>

--- a/next-client/src/components/outline/Outline.tsx
+++ b/next-client/src/components/outline/Outline.tsx
@@ -53,7 +53,7 @@ function Outline({
 
   return (
     <OutlineContext.Provider value={{ dispatch }}>
-      <Col gap={2} className="h-full bg-primary-foreground">
+      <Col gap={2} className="h-full">
         {/* Top icon */}
         <TextIcon icon={<Icons.Outline size={16} />} className="pl-5">
           Outline
@@ -117,7 +117,7 @@ function OutlineItem({
 }>) {
   return (
     // column here because opened nodes should continue the spacing.
-    <Col gap={outlineSpacing} className="max-w-[279px] bg-slate-300">
+    <Col gap={outlineSpacing} className="max-w-[279px]">
       <Row
         gap={2}
         className={`group items-center ${node.isHighlighted ? node.color : ""} ${node.hoverColor} cursor-pointer`}
@@ -136,7 +136,7 @@ function OutlineItem({
         >
           <div onClick={onBodyClick} className="flex">
             <p className="p2 overflow-ellipsis overflow-hidden select-none">
-              {title}
+              {title + "adlfadlfjaldf"}
             </p>
           </div>
           <OutlineCarrot

--- a/next-client/src/components/outline/Outline.tsx
+++ b/next-client/src/components/outline/Outline.tsx
@@ -117,7 +117,7 @@ function OutlineItem({
 }>) {
   return (
     // column here because opened nodes should continue the spacing.
-    <Col gap={outlineSpacing} className="max-w-[279px]">
+    <Col gap={outlineSpacing} className="pl-2 max-w-[279px]">
       <Row
         gap={2}
         className={`group items-center ${node.isHighlighted ? node.color : ""} ${node.hoverColor} cursor-pointer`}
@@ -130,21 +130,18 @@ function OutlineItem({
           <Icons.Minus size={12} className="stroke-[1px]" />
         </div>
         {/* Nested items should be further to the right */}
-        <Row
-          gap={2}
-          className={`pl-${heirarchyDepth * 4} w-[230px] overflow-hidden whitespace-nowrap items-center justify-between`}
+
+        <p
+          className={`pl-${heirarchyDepth * 4} p2 select-none text-ellipsis w-[230px] overflow-hidden whitespace-nowrap items-center`}
+          onClick={onBodyClick}
         >
-          <div onClick={onBodyClick} className="flex">
-            <p className="p2 overflow-ellipsis overflow-hidden select-none">
-              {title + "adlfadlfjaldf"}
-            </p>
-          </div>
-          <OutlineCarrot
-            onClick={onIconClick}
-            isOpen={node.isOpen}
-            collapsable={!!node.children?.length && !isLeafNode}
-          />
-        </Row>
+          {title + "adlfadlfjaldf"}
+        </p>
+        <OutlineCarrot
+          onClick={onIconClick}
+          isOpen={node.isOpen}
+          collapsable={!!node.children?.length && !isLeafNode}
+        />
       </Row>
 
       {node.isOpen ? children : null}

--- a/next-client/src/components/report/Report.tsx
+++ b/next-client/src/components/report/Report.tsx
@@ -32,6 +32,62 @@ import { useFocusedNode as _useFocusedNode } from "./hooks/useFocusedNode";
 import { useHashChange } from "@src/lib/hooks/useHashChange";
 import { BarChart, BarChartItemType } from "../barchart/Barchart";
 
+const ToolBarFrame = ({
+  children,
+  className,
+  stickyClass,
+}: React.PropsWithChildren<{ className?: string; stickyClass?: string }>) => (
+  <Sticky
+    className={cn(`z-50 w-full dark:bg-background bg-white`, className)}
+    stickyClass={cn("border-b shadow-sm", stickyClass)}
+  >
+    {children}
+  </Sticky>
+);
+
+function ReportLayout({
+  Outline,
+  Body,
+  ToolBar,
+}: {
+  Outline: React.ReactNode;
+  Body: React.ReactNode;
+  ToolBar: React.ReactNode;
+}) {
+  return (
+    <Col>
+      <Row>
+        {/* Left Section */}
+        <Col className="flex-grow bg-secondary">
+          {/* Section to make appearance of full width toolbar */}
+          <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
+            <div className="opacity-0 py-2">
+              <Button className="w-0 p-0 m-0"></Button>
+            </div>
+          </ToolBarFrame>
+          <div className="hidden md:block">{Outline}</div>
+        </Col>
+
+        {/* Main */}
+        <Col className="w-full md:max-w-[896px] px-3 sm:px-0">
+          <ToolBarFrame>{ToolBar}</ToolBarFrame>
+          {Body}
+        </Col>
+
+        {/* Right Section */}
+        <Col className="flex-grow bg-primary">
+          {/* Section to make appearance of full width toolbar */}
+          <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
+            <div className="opacity-0 py-2">
+              <Button className="w-0 p-0 m-0"></Button>
+            </div>
+          </ToolBarFrame>
+        </Col>
+      </Row>
+    </Col>
+  );
+}
+
 /**
  * Report Component
  *
@@ -110,22 +166,43 @@ function Report({ reportData }: { reportData: schema.ReportDataObj }) {
       {/* Wrapper div is here to just give some space at the bottom of the screen */}
       <div className="mb-36">
         {/* Toolbar is the component that has the open/close all buttons */}
-        <ReportToolbar />
-        <Row>
-          {/* Outline component for navigation and keeping track of location. Wrapped in fixed div so it moves with screen. */}
-          <div className="hidden lg:block ml-2 min-w-56 h-10" />
+        {/* <ReportToolbar /> */}
+        {/* <Row> */}
+        {/* Outline component for navigation and keeping track of location. Wrapped in fixed div so it moves with screen. */}
+        {/* <div className="hidden lg:block ml-2 min-w-56 h-10" />
           <div className="fixed top-20 bottom-0 ml-2 hidden lg:block">
             <Outline reportState={state} reportDispatch={dispatch} />
-          </div>
-          {/* Main body */}
-          <Col gap={4} className=" w-full md:max-w-[896px] m-auto px-3 sm:px-0">
+          </div> */}
+        {/* Main body */}
+        {/* <Col gap={4} className=" w-full md:max-w-[896px] m-auto px-3 sm:px-0">
             <ReportHeader reportData={reportData} />
             {state.children.map((themeNode) => (
               <Theme key={themeNode.data.id} node={themeNode} />
             ))}
           </Col>
           <div className="hidden lg:block mr-2 min-w-56 h-10" />
-        </Row>
+        </Row> */}
+        <ReportLayout
+          Body={
+            <Col
+              gap={4}
+              // className=" w-full md:max-w-[896px] m-auto px-3 sm:px-0"
+            >
+              <ReportHeader reportData={reportData} />
+              {state.children.map((themeNode) => (
+                <Theme key={themeNode.data.id} node={themeNode} />
+              ))}
+            </Col>
+          }
+          ToolBar={<ReportToolbar />}
+          Outline={
+            // <div className="hidden lg:block ml-2 min-w-56 h-10">
+            //   <div className="fixed top-20 bottom-0 ml-2 hidden lg:block">
+            <Outline reportState={state} reportDispatch={dispatch} />
+            //   </div>
+            // </div>
+          }
+        />
       </div>
     </ReportContext.Provider>
   );
@@ -138,35 +215,31 @@ export function ReportToolbar() {
   const { dispatch } = useContext(ReportContext);
   return (
     // Sticky keeps it at top of screen when scrolling down.
-    <Sticky
-      className={cn(`z-50 w-full dark:bg-background bg-white`)}
-      stickyClass="border-b shadow-sm"
+
+    <Row
+      // ! make sure this is the same width as the theme cards.
+      className={`p-2 justify-between w-full md:max-w-[896px] mx-auto`}
     >
-      <Row
-        // ! make sure this is the same width as the theme cards.
-        className={`p-2 justify-between w-full md:max-w-[896px] mx-auto`}
-      >
-        <div>
-          <Button variant={"outline"}>Edit</Button>
-        </div>
-        <Row gap={2}>
-          {/* Close all button */}
-          <Button
-            onClick={() => dispatch({ type: "closeAll", payload: { id: "" } })}
-            variant={"outline"}
-          >
-            Collapse all
-          </Button>
-          {/* Open all button  */}
-          <Button
-            onClick={() => dispatch({ type: "openAll", payload: { id: "" } })}
-            variant={"secondary"}
-          >
-            Expand all
-          </Button>
-        </Row>
+      <div>
+        <Button variant={"outline"}>Edit</Button>
+      </div>
+      <Row gap={2}>
+        {/* Close all button */}
+        <Button
+          onClick={() => dispatch({ type: "closeAll", payload: { id: "" } })}
+          variant={"outline"}
+        >
+          Collapse all
+        </Button>
+        {/* Open all button  */}
+        <Button
+          onClick={() => dispatch({ type: "openAll", payload: { id: "" } })}
+          variant={"secondary"}
+        >
+          Expand all
+        </Button>
       </Row>
-    </Sticky>
+    </Row>
   );
 }
 

--- a/next-client/src/components/report/Report.tsx
+++ b/next-client/src/components/report/Report.tsx
@@ -91,7 +91,7 @@ function ReportLayout({
             <Button variant={"outline"} className="w-0 p-0 m-0"></Button>
           </div>
         </ToolBarFrame>
-        {Outline}
+        <div className="sticky top-20">{Outline}</div>
       </Col>
 
       {/* Body section */}

--- a/next-client/src/components/report/Report.tsx
+++ b/next-client/src/components/report/Report.tsx
@@ -47,44 +47,68 @@ const ToolBarFrame = ({
 
 function ReportLayout({
   Outline,
-  Body,
+  Report,
   ToolBar,
 }: {
   Outline: React.ReactNode;
-  Body: React.ReactNode;
+  Report: React.ReactNode;
   ToolBar: React.ReactNode;
 }) {
   return (
-    <Col>
-      <Row>
-        {/* Left Section */}
-        <Col className="flex-grow bg-secondary">
-          {/* Section to make appearance of full width toolbar */}
-          <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
-            <div className="opacity-0 py-2">
-              <Button className="w-0 p-0 m-0"></Button>
-            </div>
-          </ToolBarFrame>
-          <div className="hidden md:block">{Outline}</div>
-        </Col>
+    // {/* <Row> */}
+    // {/* Left Section */}
+    // {/* <Col className="flex-grow bg-secondary"> */}
+    // {/* Section to make appearance of full width toolbar */}
+    // {/* <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
+    //       <div className="opacity-0 py-2">
+    //         <Button className="w-0 p-0 m-0"></Button>
+    //       </div>
+    //     </ToolBarFrame>
+    //     <div className="hidden md:block">{Outline}</div>
+    //   </Col> */}
 
-        {/* Main */}
-        <Col className="w-full md:max-w-[896px] px-3 sm:px-0">
-          <ToolBarFrame>{ToolBar}</ToolBarFrame>
-          {Body}
-        </Col>
+    // {/* Main */}
+    // {/* <Col className="w-full md:max-w-[896px] px-3 sm:px-0">
+    //     <ToolBarFrame>{ToolBar}</ToolBarFrame>
+    //     {Body}
+    //   </Col> */}
 
-        {/* Right Section */}
-        <Col className="flex-grow bg-primary">
-          {/* Section to make appearance of full width toolbar */}
-          <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
-            <div className="opacity-0 py-2">
-              <Button className="w-0 p-0 m-0"></Button>
-            </div>
-          </ToolBarFrame>
-        </Col>
-      </Row>
-    </Col>
+    // {/* Right Section */}
+    // {/* <Col className="flex-grow bg-primary"> */}
+    // {/* Section to make appearance of full width toolbar */}
+    // {/* <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
+    //       <div className="opacity-0 py-2">
+    //         <Button className="w-0 p-0 m-0"></Button>
+    //       </div>
+    //     </ToolBarFrame>
+    //   </Col>
+    // </Row> */}
+    <Row className="flex w-full min-h-screen">
+      {/* Outline section */}
+      <Col className="hidden md:block min-w-[279px] flex-grow">
+        <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
+          <div className="opacity-0 py-2">
+            <Button variant={"outline"} className="w-0 p-0 m-0"></Button>
+          </div>
+        </ToolBarFrame>
+        {Outline}
+      </Col>
+
+      {/* Body section */}
+      <Col className="flex-grow max-w-[896px]  mx-auto w-full">
+        <ToolBarFrame>{ToolBar}</ToolBarFrame>
+        {Report}
+      </Col>
+
+      {/* Right section */}
+      <Col className="flex-grow hidden sm:block">
+        <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
+          <div className="opacity-0 py-2">
+            <Button variant={"outline"} className="w-0 p-0 m-0"></Button>
+          </div>
+        </ToolBarFrame>
+      </Col>
+    </Row>
   );
 }
 
@@ -183,7 +207,7 @@ function Report({ reportData }: { reportData: schema.ReportDataObj }) {
           <div className="hidden lg:block mr-2 min-w-56 h-10" />
         </Row> */}
         <ReportLayout
-          Body={
+          Report={
             <Col
               gap={4}
               // className=" w-full md:max-w-[896px] m-auto px-3 sm:px-0"
@@ -218,7 +242,7 @@ export function ReportToolbar() {
 
     <Row
       // ! make sure this is the same width as the theme cards.
-      className={`p-2 justify-between w-full md:max-w-[896px] mx-auto`}
+      className={`p-2 justify-between w-full mx-auto`}
     >
       <div>
         <Button variant={"outline"}>Edit</Button>

--- a/next-client/src/components/report/Report.tsx
+++ b/next-client/src/components/report/Report.tsx
@@ -55,47 +55,17 @@ function ReportLayout({
   ToolBar: React.ReactNode;
 }) {
   return (
-    // {/* <Row> */}
-    // {/* Left Section */}
-    // {/* <Col className="flex-grow bg-secondary"> */}
-    // {/* Section to make appearance of full width toolbar */}
-    // {/* <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
-    //       <div className="opacity-0 py-2">
-    //         <Button className="w-0 p-0 m-0"></Button>
-    //       </div>
-    //     </ToolBarFrame>
-    //     <div className="hidden md:block">{Outline}</div>
-    //   </Col> */}
-
-    // {/* Main */}
-    // {/* <Col className="w-full md:max-w-[896px] px-3 sm:px-0">
-    //     <ToolBarFrame>{ToolBar}</ToolBarFrame>
-    //     {Body}
-    //   </Col> */}
-
-    // {/* Right Section */}
-    // {/* <Col className="flex-grow bg-primary"> */}
-    // {/* Section to make appearance of full width toolbar */}
-    // {/* <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
-    //       <div className="opacity-0 py-2">
-    //         <Button className="w-0 p-0 m-0"></Button>
-    //       </div>
-    //     </ToolBarFrame>
-    //   </Col>
-    // </Row> */}
     <Row className="flex w-full min-h-screen">
       {/* Outline section */}
       <Col className="hidden md:block min-w-[279px] flex-grow">
         <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
-          <div className="opacity-0 py-2">
-            <Button variant={"outline"} className="w-0 p-0 m-0"></Button>
-          </div>
+          <div className="w-full h-14" />
         </ToolBarFrame>
         <div className="sticky top-20">{Outline}</div>
       </Col>
 
       {/* Body section */}
-      <Col className="flex-grow max-w-[896px]  mx-auto w-full">
+      <Col className="flex-grow max-w-[896px] mx-auto w-full">
         <ToolBarFrame>{ToolBar}</ToolBarFrame>
         {Report}
       </Col>
@@ -103,9 +73,7 @@ function ReportLayout({
       {/* Right section */}
       <Col className="flex-grow hidden sm:block">
         <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
-          <div className="opacity-0 py-2">
-            <Button variant={"outline"} className="w-0 p-0 m-0"></Button>
-          </div>
+          <div className="w-full h-14" />
         </ToolBarFrame>
       </Col>
     </Row>
@@ -189,28 +157,12 @@ function Report({ reportData }: { reportData: schema.ReportDataObj }) {
     >
       {/* Wrapper div is here to just give some space at the bottom of the screen */}
       <div className="mb-36">
-        {/* Toolbar is the component that has the open/close all buttons */}
-        {/* <ReportToolbar /> */}
-        {/* <Row> */}
-        {/* Outline component for navigation and keeping track of location. Wrapped in fixed div so it moves with screen. */}
-        {/* <div className="hidden lg:block ml-2 min-w-56 h-10" />
-          <div className="fixed top-20 bottom-0 ml-2 hidden lg:block">
-            <Outline reportState={state} reportDispatch={dispatch} />
-          </div> */}
-        {/* Main body */}
-        {/* <Col gap={4} className=" w-full md:max-w-[896px] m-auto px-3 sm:px-0">
-            <ReportHeader reportData={reportData} />
-            {state.children.map((themeNode) => (
-              <Theme key={themeNode.data.id} node={themeNode} />
-            ))}
-          </Col>
-          <div className="hidden lg:block mr-2 min-w-56 h-10" />
-        </Row> */}
         <ReportLayout
           Report={
             <Col
               gap={4}
               // className=" w-full md:max-w-[896px] m-auto px-3 sm:px-0"
+              className="px-3 sm:px-0"
             >
               <ReportHeader reportData={reportData} />
               {state.children.map((themeNode) => (
@@ -219,13 +171,7 @@ function Report({ reportData }: { reportData: schema.ReportDataObj }) {
             </Col>
           }
           ToolBar={<ReportToolbar />}
-          Outline={
-            // <div className="hidden lg:block ml-2 min-w-56 h-10">
-            //   <div className="fixed top-20 bottom-0 ml-2 hidden lg:block">
-            <Outline reportState={state} reportDispatch={dispatch} />
-            //   </div>
-            // </div>
-          }
+          Outline={<Outline reportState={state} reportDispatch={dispatch} />}
         />
       </div>
     </ReportContext.Provider>

--- a/next-client/src/components/report/Report.tsx
+++ b/next-client/src/components/report/Report.tsx
@@ -159,11 +159,7 @@ function Report({ reportData }: { reportData: schema.ReportDataObj }) {
       <div className="mb-36">
         <ReportLayout
           Report={
-            <Col
-              gap={4}
-              // className=" w-full md:max-w-[896px] m-auto px-3 sm:px-0"
-              className="px-3 sm:px-0"
-            >
+            <Col gap={4} className="px-3">
               <ReportHeader reportData={reportData} />
               {state.children.map((themeNode) => (
                 <Theme key={themeNode.data.id} node={themeNode} />


### PR DESCRIPTION
So I've been trying to figure out a better way of handling layout on the report screen. Before the major troubles were the toolbar, outline, and all the pieces clashing together.


Here's what it looks like at full width. There's about an even amount of padding between the right side of the screen and the outline. **An alternative could be to try and make the Report more towards the center of the screen**, let me know what you think.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/7f9b43ac-1c26-44ce-bc6b-13425269d6a1" />

As the page size decreases, the margins on the side of the report decrease and as the window buts up against the report, it'll shrink while the outline stays the same size.

![image](https://github.com/user-attachments/assets/d8541c6c-d9fc-495c-9bfc-ba6210649df6)


![image](https://github.com/user-attachments/assets/754d5b32-4a52-46be-9ae1-cc3c346d01d6)

At the md breakpoint, the outline goes away since it will take up most of the space.
md width
![image](https://github.com/user-attachments/assets/3b260228-3ff2-4b49-93b9-95f6c279aedf)

Here's the mobile width. 
mobile width
![image](https://github.com/user-attachments/assets/8bfded32-a9da-448e-b47c-7e9de49f4f4b)

@colleenm lmk if the outline issues you were having still happen.
I'll share these images with Pawel.
