### PR TITLE
move OAI keys to headers

### DIFF
--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -12,7 +12,6 @@ const llmConfig = z.object(
     model_name: z.string(),
     system_prompt: z.string(),
     user_prompt: z.string(),
-    api_key: z.string(),
   },
   { invalid_type_error: "Invalid llmConfig" },
 );

--- a/express-server/src/pipeline/claimsStep.ts
+++ b/express-server/src/pipeline/claimsStep.ts
@@ -11,7 +11,7 @@ const typedFetch =
       body: JSON.stringify(bodySchema.parse(body) as z.infer<T>),
       headers: {
         "Content-Type": "application/json",
-        "openai-api-key" : openaiAPIKey
+        "openai-api-key": openaiAPIKey,
       },
     });
 
@@ -24,7 +24,11 @@ const logger =
     return arg;
   };
 
-export async function claimsPipelineStep(env: Env, openaiAPIKey: string, input: ClaimsStep["data"]) {
+export async function claimsPipelineStep(
+  env: Env,
+  openaiAPIKey: string,
+  input: ClaimsStep["data"],
+) {
   const { data, usage } = await pyserverFetchClaims(
     `${env.PYSERVER_URL}/claims`,
     input,

--- a/express-server/src/pipeline/claimsStep.ts
+++ b/express-server/src/pipeline/claimsStep.ts
@@ -5,12 +5,13 @@ import { z } from "zod";
 
 const typedFetch =
   <T extends z.ZodTypeAny>(bodySchema: T) =>
-  async (url: string, body: z.infer<T>) =>
+  async (url: string, body: z.infer<T>, openaiAPIKey: string) =>
     await fetch(url, {
       method: "POST",
       body: JSON.stringify(bodySchema.parse(body) as z.infer<T>),
       headers: {
         "Content-Type": "application/json",
+        "openai-api-key" : openaiAPIKey
       },
     });
 
@@ -23,10 +24,11 @@ const logger =
     return arg;
   };
 
-export async function claimsPipelineStep(env: Env, input: ClaimsStep["data"]) {
+export async function claimsPipelineStep(env: Env, openaiAPIKey: string, input: ClaimsStep["data"]) {
   const { data, usage } = await pyserverFetchClaims(
     `${env.PYSERVER_URL}/claims`,
     input,
+    openaiAPIKey,
   )
     .then((res) => res.json())
     .then(logger("claims step returns: "))

--- a/express-server/src/pipeline/sortClaimsTree.ts
+++ b/express-server/src/pipeline/sortClaimsTree.ts
@@ -5,12 +5,13 @@ import { z } from "zod";
 
 const typedFetch =
   <T extends z.ZodTypeAny>(bodySchema: T) =>
-  async (url: string, body: z.infer<T>) =>
+  async (url: string, body: z.infer<T>, openaiAPIKey: string) =>
     await fetch(url, {
       method: "PUT",
       body: JSON.stringify(bodySchema.parse(body) as z.infer<T>),
       headers: {
         "Content-Type": "application/json",
+        "openai-api-key" : openaiAPIKey
       },
     });
 
@@ -27,11 +28,13 @@ const logger =
 
 export async function sortClaimsTreePipelineStep(
   env: Env,
+  openaiAPIKey: string,
   data: SortClaimTreeStep["data"],
 ) {
   return await pyserverFetchSortClaimsTree(
     `${env.PYSERVER_URL}/sort_claims_tree`,
     data,
+    openaiAPIKey,
   )
     .then((res) => res.json())
     .then(logger("sort claims step returns: "))

--- a/express-server/src/pipeline/sortClaimsTree.ts
+++ b/express-server/src/pipeline/sortClaimsTree.ts
@@ -11,7 +11,7 @@ const typedFetch =
       body: JSON.stringify(bodySchema.parse(body) as z.infer<T>),
       headers: {
         "Content-Type": "application/json",
-        "openai-api-key" : openaiAPIKey
+        "openai-api-key": openaiAPIKey,
       },
     });
 

--- a/express-server/src/pipeline/topicTreeStep.ts
+++ b/express-server/src/pipeline/topicTreeStep.ts
@@ -11,7 +11,7 @@ const typedFetch =
       body: JSON.stringify(bodySchema.parse(body) as z.infer<T>),
       headers: {
         "Content-Type": "application/json",
-        "openai-api-key" : openaiAPIKey
+        "openai-api-key": openaiAPIKey,
       },
     });
 
@@ -32,7 +32,7 @@ export async function topicTreePipelineStep(
   const { data, usage } = await pyserverFetchTopicTree(
     `${env.PYSERVER_URL}/topic_tree`,
     input,
-    openaiAPIKey
+    openaiAPIKey,
   )
     .then((res) => res.json())
     .then(logger("topic tree step returns: "))

--- a/express-server/src/pipeline/topicTreeStep.ts
+++ b/express-server/src/pipeline/topicTreeStep.ts
@@ -5,12 +5,13 @@ import { z } from "zod";
 
 const typedFetch =
   <T extends z.ZodTypeAny>(bodySchema: T) =>
-  async (url: string, body: z.infer<T>) =>
+  async (url: string, body: z.infer<T>, openaiAPIKey: string) =>
     await fetch(url, {
       method: "POST",
       body: JSON.stringify(bodySchema.parse(body) as z.infer<T>),
       headers: {
         "Content-Type": "application/json",
+        "openai-api-key" : openaiAPIKey
       },
     });
 
@@ -25,11 +26,13 @@ const logger =
 
 export async function topicTreePipelineStep(
   env: Env,
+  openaiAPIKey: string,
   input: TopicTreeStep["data"],
 ) {
   const { data, usage } = await pyserverFetchTopicTree(
     `${env.PYSERVER_URL}/topic_tree`,
     input,
+    openaiAPIKey
   )
     .then((res) => res.json())
     .then(logger("topic tree step returns: "))

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -48,8 +48,7 @@ const setupPipelineWorker = (connection: Redis) => {
       const makeLLMConfig = (user_prompt: string): apiPyserver.LLMConfig => ({
         system_prompt: config.systemInstructions,
         user_prompt,
-        model_name: config.model || "gpt-4o-mini",
-        api_key: config.apiKey,
+        model_name: config.model || "gpt-4o-mini"
       });
 
       const options: schema.OldOptions = { ...defaultConfig, ...config };
@@ -87,7 +86,7 @@ const setupPipelineWorker = (connection: Redis) => {
         status: api.reportJobStatus.Values.clustering,
       });
 
-      const { data: taxonomy } = await topicTreePipelineStep(env, {
+      const { data: taxonomy } = await topicTreePipelineStep(env, config.apiKey, {
         comments,
         llm: topicTreeLLMConfig,
       });
@@ -98,7 +97,7 @@ const setupPipelineWorker = (connection: Redis) => {
       await job.updateProgress({
         status: api.reportJobStatus.Values.extraction,
       });
-      const { claims_tree } = await claimsPipelineStep(env, {
+      const { claims_tree } = await claimsPipelineStep(env, config.apiKey, {
         tree: { taxonomy },
         comments,
         llm: claimsLLMConfig,
@@ -111,7 +110,7 @@ const setupPipelineWorker = (connection: Redis) => {
       // TODO: more principled way of configuring this?
       const numPeopleSort = "numPeople";
 
-      const { data: tree } = await sortClaimsTreePipelineStep(env, {
+      const { data: tree } = await sortClaimsTreePipelineStep(env, config.apiKey, {
         tree: claims_tree,
         llm: dedupLLMConfig,
         sort: numPeopleSort,

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -48,7 +48,7 @@ const setupPipelineWorker = (connection: Redis) => {
       const makeLLMConfig = (user_prompt: string): apiPyserver.LLMConfig => ({
         system_prompt: config.systemInstructions,
         user_prompt,
-        model_name: config.model || "gpt-4o-mini"
+        model_name: config.model || "gpt-4o-mini",
       });
 
       const options: schema.OldOptions = { ...defaultConfig, ...config };
@@ -86,10 +86,14 @@ const setupPipelineWorker = (connection: Redis) => {
         status: api.reportJobStatus.Values.clustering,
       });
 
-      const { data: taxonomy } = await topicTreePipelineStep(env, config.apiKey, {
-        comments,
-        llm: topicTreeLLMConfig,
-      });
+      const { data: taxonomy } = await topicTreePipelineStep(
+        env,
+        config.apiKey,
+        {
+          comments,
+          llm: topicTreeLLMConfig,
+        },
+      );
 
       console.log(
         "Step 2: extracting claims matching the topics and subtopics",
@@ -110,11 +114,15 @@ const setupPipelineWorker = (connection: Redis) => {
       // TODO: more principled way of configuring this?
       const numPeopleSort = "numPeople";
 
-      const { data: tree } = await sortClaimsTreePipelineStep(env, config.apiKey, {
-        tree: claims_tree,
-        llm: dedupLLMConfig,
-        sort: numPeopleSort,
-      });
+      const { data: tree } = await sortClaimsTreePipelineStep(
+        env,
+        config.apiKey,
+        {
+          tree: claims_tree,
+          llm: dedupLLMConfig,
+          sort: numPeopleSort,
+        },
+      );
 
       const newTax: schema.Taxonomy = taxonomy.map((t) => ({
         ...t,

--- a/pyserver/test_pipeline.py
+++ b/pyserver/test_pipeline.py
@@ -8,11 +8,12 @@ import os
 ##################
 # Sample inputs  #
 #----------------#
-
 min_pets_1 = [{"id":"1", "text":"I love cats", "speaker" : "Alice"}]
-min_pets_3 = [{"id":"1", "text":"I love cats"},{"id":"2","text":"dogs are great"},{"id":"3","text":"I'm not sure about birds"}]
-dupes_pets_5 = [{"id":"a", "text":"I love cats"},{"id":"b", "text":"dogs are great"},{"id":"c","text":"I'm not sure about birds"},\
-                {"id":"d","text":"I really really love cats"},{"id":"e","text":"I don't know about birds"}]
+
+speaker_pets_3 = [{"id":"a", "text":"I love cats", "speaker" : "Alice"},\
+                {"id":"b", "text":"dogs are great", "speaker" : "Bob"},\
+                {"id":"c","text":"I'm not sure about birds", "speaker" : "Charles"}]
+
 longer_pets_15 = [{"id":"0", "text":"I love cats", "speaker" : "Alice"},{"id":"1","text":"I really really love dogs", "speaker" : "Bob"},{"id":"2","text":"I'm not sure about birds", "speaker" : "Charles"},\
   {"id":"3","text" : "Cats are my favorite", "speaker" : "Dany"},{"id":"4","text" : "Lizards are terrifying", "speaker" : "Alice"}, {"id":"5", "text" : "Lizards are so friggin scary", "speaker" : "Charles"},\
   {"id":"6","text" : "Dogs are the best", "speaker" : "Elinor"}, {"id":"7","text":  "No seriously dogs are great", "speaker" : "Bob"}, {"id":"8","text" : "Birds I'm hesitant about", "speaker" : "Elinor"},\
@@ -21,140 +22,143 @@ longer_pets_15 = [{"id":"0", "text":"I love cats", "speaker" : "Alice"},{"id":"1
 
 topic_tree_4o = {"taxonomy" : [{'topicName': 'Pets', 'topicShortDescription': 'General opinions about common household pets.', 'subtopics': [{'subtopicName': 'Cats', 'subtopicShortDescription': 'Positive sentiments towards cats.'}, {'subtopicName': 'Dogs', 'subtopicShortDescription': 'Positive sentiments towards dogs.'}, {'subtopicName': 'Birds', 'subtopicShortDescription': 'Uncertainty or mixed feelings about birds.'}]}]}
 
-speaker_pets_3 = [{"id":"a", "text":"I love cats", "speaker" : "Alice"},\
-                {"id":"b", "text":"dogs are great", "speaker" : "Bob"},\
-                {"id":"c","text":"I'm not sure about birds", "speaker" : "Charles"}]
-            ##    {"id":"d","text":"I really really love cats"},{"id":"e","text":"I don't know about birds"}]
-
-# NOTE: gpt-4o-mini is cheaper/better for basic tests, but it fails on some very basic deduplication
-API_KEY = os.getenv('OPENAI_API_KEY')
-base_llm = {
-  "model_name" : "gpt-4o-mini",
-  "system_prompt": config.SYSTEM_PROMPT,
-  "api_key" : API_KEY
-}
-
 dupe_claims_4o_ids = {'Pets': {'total': 5, 'subtopics': {'Cats': {'total': 2, 'claims': [{'claim': 'Cats are the best household pets.', 'quote': 'I love cats', 'topicName': 'Pets', 'subtopicName': 'Cats', 'commentId': 'a'}, {'claim': 'Cats are the best household pets.', 'quote': 'I really really love cats', 'topicName': 'Pets', 'subtopicName': 'Cats', 'commentId': 'd'}]}, 'Dogs': {'total': 1, 'claims': [{'claim': 'Dogs are superior pets.', 'quote': 'dogs are great', 'topicName': 'Pets', 'subtopicName': 'Dogs', 'commentId': 'b'}]}, 'Birds': {'total': 2, 'claims': [{'claim': 'Birds are not ideal pets for everyone.', 'quote': "I'm not sure about birds.", 'topicName': 'Pets', 'subtopicName': 'Birds', 'commentId': 'c'}, {'claim': 'There is uncertainty about birds as pets.', 'quote': "I don't know about birds.", 'topicName': 'Pets', 'subtopicName': 'Birds', 'commentId': 'e'}]}}}}
 
 dupe_claims_4o_speakers = {'Pets': {'total': 5, 'subtopics': {'Cats': {'total': 2, 'claims': [{'claim': 'Cats are the best household pets.', 'quote': 'I love cats', 'topicName': 'Pets', 'subtopicName': 'Cats', 'commentId': 'a', "speaker" : "Alice"}, {'claim': 'Cats are the best household pets.', 'quote': 'I really really love cats', 'topicName': 'Pets', 'subtopicName': 'Cats', 'commentId': 'd', "speaker" : "Dany"}]}, 'Dogs': {'total': 1, 'claims': [{'claim': 'Dogs are superior pets.', 'quote': 'dogs are great', 'topicName': 'Pets', 'subtopicName': 'Dogs', 'commentId': 'b', "speaker" : "Bob"}]}, 'Birds': {'total': 2, 'claims': [{'claim': 'Birds are not ideal pets for everyone.', 'quote': "I'm not sure about birds.", 'topicName': 'Pets', 'subtopicName': 'Birds', 'commentId': 'c', "speaker" : "Charles"}, {'claim': 'There is uncertainty about birds as pets.', 'quote': "I don't know about birds.", 'topicName': 'Pets', 'subtopicName': 'Birds', 'commentId': 'e', "speaker" : "Elinor"}]}}}}
 
+#################
+# Shared config #
+#---------------#
+# NOTE: gpt-4o-mini is cheaper/better for basic tests, but it fails on some very basic deduplication
+base_llm = {
+  "model_name" : "gpt-4o-mini",
+  "system_prompt": config.SYSTEM_PROMPT
+}
 
-
-# maximize readability
+# utils: maximize readability
 def json_print(json_obj):
   print(json.dumps(json_obj,indent=4))
+
+################
+# Auth & tests #
+#--------------#
+# set in env shell when running tests
+API_KEY = os.getenv('OPENAI_API_KEY')
+# various header cases
+valid_headers = {"openai-api-key" : API_KEY}
+bad_headers = {"openai-api-key" : "sk-proj-123456789"}
+no_headers = {}
 
 ###############
 # Basic tests #
 #-------------#
 
-def test_topic_tree(comments=min_pets_3):
+def test_topic_tree(comments=speaker_pets_3, headers=valid_headers):
   llm = base_llm
   llm.update({"user_prompt" : config.COMMENT_TO_TREE_PROMPT})
   request ={"llm" : llm, "comments" : comments}
-  response = client.post("/topic_tree/", json=request)
+  response = client.post("/topic_tree/", json=request, headers=headers)
   json_print(response.json())
 
-def test_claims(comments=dupes_pets_5):
+def test_claims(comments=speaker_pets_3, headers=valid_headers):
   llm = base_llm
   llm.update({"user_prompt" : config.COMMENT_TO_CLAIMS_PROMPT})
   request ={"llm" : llm, "comments" : comments, "tree" : topic_tree_4o}
-  response = client.post("/claims/", json=request)
+  response = client.post("/claims/", json=request, headers=headers)
   print(json.dumps(response.json(), indent=4))
 
-def test_dupes(claims_tree=dupe_claims_4o_speakers):
+def test_dupes(claims_tree=dupe_claims_4o_speakers, headers=valid_headers):
   llm = base_llm
   llm.update({"user_prompt" : config.CLAIM_DEDUP_PROMPT})
   request ={"llm" : llm, "tree" : claims_tree, "sort" : "numPeople"}
-  response = client.put("/sort_claims_tree/", json=request)
+  response = client.put("/sort_claims_tree/", json=request, headers=headers)
   print(json.dumps(response.json(), indent=4))
 
-def test_full_pipeline(comments=dupes_pets_5):
+def test_full_pipeline(comments=speaker_pets_3, headers=valid_headers):
   print("Step 1: Topic tree\n\n")
   llm = base_llm
   # fancier model for more precise deduplication
   llm.update({"model_name" : "gpt-4-turbo-preview"})
   llm.update({"user_prompt" : config.COMMENT_TO_TREE_PROMPT})
   request ={"llm" : llm, "comments" : comments} 
-  tree = client.post("/topic_tree/", json=request).json()["data"]
+  tree = client.post("/topic_tree/", json=request, headers=headers).json()["data"]
   json_print(tree)
 
   print("\n\nStep 2: Claims\n\n")
   llm.update({"user_prompt" : config.COMMENT_TO_CLAIMS_PROMPT})
   request ={"llm" : llm, "comments" : comments, "tree" : {"taxonomy" :tree}}
-  claims = client.post("/claims/", json=request).json()["data"]
+  claims = client.post("/claims/", json=request, headers=headers).json()["data"]
   json_print(claims)
 
   print("\n\nStep 3: Dedup & sort\n\n")
   llm.update({"user_prompt" : config.CLAIM_DEDUP_PROMPT})
   request ={"llm" : llm, "tree" : claims , "sort" : "numPeople"}
-  full_tree = client.put("/sort_claims_tree/", json=request)
+  full_tree = client.put("/sort_claims_tree/", json=request, headers=headers)
   print(json.dumps(full_tree.json(), indent=4))
 
 #################
 # W&B log tests #
 #---------------#
 
-def test_wb_topic_tree():
+def test_wb_topic_tree(comments=speaker_pets_3, headers=valid_headers):
   llm = base_llm
   llm.update({"user_prompt" : config.COMMENT_TO_TREE_PROMPT})
-  request ={"llm" : llm, "comments" : min_pets_3}
-  response = client.post("/topic_tree/?log_to_wandb=local_test_0", json=request)
+  request ={"llm" : llm, "comments" : comments}
+  response = client.post("/topic_tree/?log_to_wandb=local_test_0", json=request, headers=headers)
   json_print(response.json())
 
-def test_wb_claims():
+def test_wb_claims(headers=valid_headers):
   llm = base_llm
   llm.update({"user_prompt" : config.COMMENT_TO_CLAIMS_PROMPT})
   request ={"llm" : llm, "comments" : dupes_pets_5, "tree" : topic_tree_4o}
-  response = client.post("/claims/?log_to_wandb=local_test_0", json=request)
+  response = client.post("/claims/?log_to_wandb=local_test_0", json=request, headers=headers)
   json_print(response.json())
 
-def test_wb_dupes():
+def test_wb_dupes(headers=valid_headers):
   llm = base_llm
   llm.update({"user_prompt" : config.CLAIM_DEDUP_PROMPT})
   request ={"llm" : llm, "tree" : dupe_claims_4o_ids}
-  response = client.put("/sort_claims_tree/?log_to_wandb=local_test_0", json=request)
+  response = client.put("/sort_claims_tree/?log_to_wandb=local_test_0", json=request, headers=headers)
   json_print(response.json())
 
-def test_wb_full_pipeline(comments=dupes_pets_5):
+def test_wb_full_pipeline(comments=speaker_pets_3, headers=valid_headers):
   print("Step 1: Topic tree\n\n")
   llm = base_llm
   # fancier model for more precise deduplication
   llm.update({"model_name" : "gpt-4o"})
   llm.update({"user_prompt" : config.COMMENT_TO_TREE_PROMPT})
   request ={"llm" : llm, "comments" : comments} 
-  tree = client.post("/topic_tree/?log_to_wandb=local_test_0", json=request).json()["data"]
+  tree = client.post("/topic_tree/?log_to_wandb=local_test_0", json=request, headers=headers).json()["data"]
   json_print(tree)
 
   print("\n\nStep 2: Claims\n\n")
   llm.update({"user_prompt" : config.COMMENT_TO_CLAIMS_PROMPT})
   request ={"llm" : llm, "comments" : comments, "tree" : {"taxonomy" :tree}}
-  claims = client.post("/claims/?log_to_wandb=local_test_0", json=request).json()["data"]
+  claims = client.post("/claims/?log_to_wandb=local_test_0", json=request, headers=headers).json()["data"]
   json_print(claims)
 
   print("\n\nStep 3: Dedup & sort\n\n")
   llm.update({"user_prompt" : config.CLAIM_DEDUP_PROMPT})
   request ={"llm" : llm, "tree" : claims }
-  full_tree = client.put("/sort_claims_tree/?log_to_wandb=local_test_0", json=request).json()["data"]
-  json_print(full_tree)
+  full_tree = client.put("/sort_claims_tree/?log_to_wandb=local_test_0", json=request, headers=headers)
+  json_print(full_tree.json())
 
 
 #############
 # Run tests #
 #-----------#
 client = TestClient(app)
+
 #test_claims(longer_pets_15)
 #test_dupes()
+#test_claims(headers=valid_headers)
+#test_dupes(headers=bad_headers)
+#test_full_pipeline(longer_pets_15, headers=bad_headers)
 
-#test_topic_tree()
-#test_claims()
-#test_dupes()
-test_full_pipeline(longer_pets_15)
-
-#test_wb_topic_tree()
+#test_wb_topic_tree(headers=bad_headers)
 #test_wb_claims()
 #test_wb_dupes()
-#test_wb_full_pipeline(longer_pets_15)
+test_wb_full_pipeline(longer_pets_15, headers=valid_headers)
 
 # TODO: test with edge case inputs
 # TODO: add assertions


### PR DESCRIPTION
- changes pyserver routes to take OAI api keys as headers instead of as request param in the json body
- changes TS calling accordingly (@Brandon-Perry sincere apologies for style/convention misses here—was only focused on getting it to work)
- pyserver routes crash early if not authenticated
- now we don't pass around a key in the body which might accidentally be logged
- may add extra middleware per Portia's recommendations and wanted to start a placeholder PR
- in the future, will want to consider how this extends to multiple keys, e.g. calling Claude instead