### PR TITLE
Alpha launch placeholder: reach out instead of pasting a key

### DIFF
--- a/next-client/src/components/create/CreateReport.tsx
+++ b/next-client/src/components/create/CreateReport.tsx
@@ -478,14 +478,14 @@ const AlphaLaunchInvite = () => {
     <Col gap={2}>
       <h4>Alpha Launch Invite</h4>
       <p>
-        For access, please email hello@objective.is with your Talk to the City account name/email
-        and a description of your use case — we're excited to work with you and actively generating
-        reports on interesting public data!
+        For access, please email hello@objective.is with your Talk to the City
+        account name/email and a description of your use case — we're excited to
+        work with you and actively generating reports on interesting public
+        data!
       </p>
     </Col>
   );
-}
-
+};
 
 const CustomizePrompts = () => (
   <Col gap={8}>

--- a/next-client/src/components/create/CreateReport.tsx
+++ b/next-client/src/components/create/CreateReport.tsx
@@ -193,7 +193,7 @@ function CreateReportComponent({ token }: { token: string | null }) {
             <FormHeader />
             <FormDescription />
             <FormDataInput files={files} setFiles={setFiles} />
-            <FormOpenAIKey />
+            <AlphaLaunchInvite />
             <CustomizePrompts />
             <CostEstimate files={files} />
             <div>
@@ -472,6 +472,20 @@ const FormOpenAIKey = () => {
     </Col>
   );
 };
+
+const AlphaLaunchInvite = () => {
+  return (
+    <Col gap={2}>
+      <h4>Alpha Launch Invite</h4>
+      <p>
+        For access, please email hello@objective.is with your Talk to the City account name/email
+        and a description of your use case — we're excited to work with you and actively generating
+        reports on interesting public data!
+      </p>
+    </Col>
+  );
+}
+
 
 const CustomizePrompts = () => (
   <Col gap={8}>


### PR DESCRIPTION
shortcut to keeping alpha launch invite-only by not showing a box where folks can paste keys — open to style/wording improvements! ideally they could instead submit a form describing their use case that would auto-populate their account email & that we could easily review :)