### PR TITLE
increase timeout so we don't crash on long reports

### DIFF
--- a/express-server/src/pipeline/claimsStep.ts
+++ b/express-server/src/pipeline/claimsStep.ts
@@ -12,6 +12,9 @@ const typedFetch =
       headers: {
         "Content-Type": "application/json",
       },
+      // wait for 7 minutes for full claims list
+      // TODO: use message queue instead
+      signal: AbortSignal.timeout(420000),
     });
 
 const pyserverFetchClaims = typedFetch(apiPyserver.claimsRequest);


### PR DESCRIPTION
super quick one — this fixes the crash in prod for longer reports by not timing out on the (very long, sequential) claims extraction step
in the future, we should use a messaging queue :)
also this puts the cutoff at 7 mins, which is big enough for my DeepSeek data set and probably not for all reports, so let's keep an eye on this part in the future