### PR TITLE
compute and log cost and tokens for LLM pipeline

### DIFF
--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -171,6 +171,7 @@ export const topicTreeResponse = z.object(
   {
     data: partialTopic.array(),
     usage,
+    cost: z.number(),
   },
   { invalid_type_error: "Invalid topic tree response" },
 );
@@ -196,6 +197,7 @@ export type ClaimsRequest = z.infer<typeof claimsRequest>;
 export const claimsReply = z.object({
   data: claimsTree,
   usage,
+  cost: z.number(),
 });
 
 //  ********************************
@@ -211,6 +213,8 @@ export type SortClaimsTreeRequest = z.infer<typeof sortClaimsTreeRequest>;
 
 export const sortClaimsTreeResponse = z.object({
   data: sortedTopic.array(),
+  usage: usage,
+  cost: z.number()
 });
 
 export type SortClaimsTreeResponse = z.infer<typeof sortClaimsTreeResponse>;
@@ -250,6 +254,7 @@ export const cruxesResponse = z.object({
   controversyMatrix: controversyMatrix,
   topCruxes: scoredCruxPair.array(),
   usage,
+  cost: z.number()
 });
 
 export const cruxesRequest = z.object({

--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -214,7 +214,7 @@ export type SortClaimsTreeRequest = z.infer<typeof sortClaimsTreeRequest>;
 export const sortClaimsTreeResponse = z.object({
   data: sortedTopic.array(),
   usage: usage,
-  cost: z.number()
+  cost: z.number(),
 });
 
 export type SortClaimsTreeResponse = z.infer<typeof sortClaimsTreeResponse>;
@@ -254,7 +254,7 @@ export const cruxesResponse = z.object({
   controversyMatrix: controversyMatrix,
   topCruxes: scoredCruxPair.array(),
   usage,
-  cost: z.number()
+  cost: z.number(),
 });
 
 export const cruxesRequest = z.object({

--- a/common/schema.ts
+++ b/common/schema.ts
@@ -138,12 +138,20 @@ export const tracker = z.object({
   costs: z.number(),
   prompt_tokens: z.number(),
   completion_tokens: z.number(),
+  total_tokens: z.number(),
   unmatchedClaims: z.array(oldclaim),
   end: z.number().optional(),
   duration: z.string().optional(),
 });
 
 export type Tracker = z.infer<typeof tracker>;
+
+export const usageTokens = z.object({
+  prompt_tokens: z.number(),
+  completion_tokens: z.number(),
+  total_tokens: z.number(),
+})
+export type UsageTokens = z.infer<typeof usageTokens>;
 
 export const llmSubtopic = z.object({
   subtopicName: z.string(),

--- a/common/schema.ts
+++ b/common/schema.ts
@@ -150,7 +150,7 @@ export const usageTokens = z.object({
   prompt_tokens: z.number(),
   completion_tokens: z.number(),
   total_tokens: z.number(),
-})
+});
 export type UsageTokens = z.infer<typeof usageTokens>;
 
 export const llmSubtopic = z.object({

--- a/express-server/src/pipeline/claimsStep.ts
+++ b/express-server/src/pipeline/claimsStep.ts
@@ -27,7 +27,7 @@ const logger =
   };
 
 export async function claimsPipelineStep(env: Env, input: ClaimsStep["data"]) {
-  const { data, usage } = await pyserverFetchClaims(
+  const { data, usage, cost } = await pyserverFetchClaims(
     `${env.PYSERVER_URL}/claims/`,
     input,
   )
@@ -35,5 +35,5 @@ export async function claimsPipelineStep(env: Env, input: ClaimsStep["data"]) {
     .then(logger("claims step returns: "))
     .then(apiPyserver.claimsReply.parse);
 
-  return { claims_tree: data, usage };
+  return { claims_tree: data, usage, cost};
 }

--- a/express-server/src/pipeline/claimsStep.ts
+++ b/express-server/src/pipeline/claimsStep.ts
@@ -35,5 +35,5 @@ export async function claimsPipelineStep(env: Env, input: ClaimsStep["data"]) {
     .then(logger("claims step returns: "))
     .then(apiPyserver.claimsReply.parse);
 
-  return { claims_tree: data, usage, cost};
+  return { claims_tree: data, usage, cost };
 }

--- a/express-server/src/pipeline/cruxesStep.ts
+++ b/express-server/src/pipeline/cruxesStep.ts
@@ -24,11 +24,11 @@ const logger =
   };
 
 export async function cruxesPipelineStep(env: Env, input: CruxesStep["data"]) {
-  const { cruxClaims, controversyMatrix, topCruxes, usage } =
+  const { cruxClaims, controversyMatrix, topCruxes, usage, cost } =
     await pyserverFetchClaims(`${env.PYSERVER_URL}/cruxes/`, input)
       .then((res) => res.json())
       .then(logger("cruxes step returns: "))
       .then(apiPyserver.cruxesResponse.parse);
 
-  return { cruxClaims, controversyMatrix, topCruxes, usage };
+  return { cruxClaims, controversyMatrix, topCruxes, usage, cost};
 }

--- a/express-server/src/pipeline/cruxesStep.ts
+++ b/express-server/src/pipeline/cruxesStep.ts
@@ -30,5 +30,5 @@ export async function cruxesPipelineStep(env: Env, input: CruxesStep["data"]) {
       .then(logger("cruxes step returns: "))
       .then(apiPyserver.cruxesResponse.parse);
 
-  return { cruxClaims, controversyMatrix, topCruxes, usage, cost};
+  return { cruxClaims, controversyMatrix, topCruxes, usage, cost };
 }

--- a/express-server/src/pipeline/sortClaimsTree.ts
+++ b/express-server/src/pipeline/sortClaimsTree.ts
@@ -27,13 +27,14 @@ const logger =
 
 export async function sortClaimsTreePipelineStep(
   env: Env,
-  data: SortClaimTreeStep["data"],
+  input: SortClaimTreeStep["data"],
 ) {
-  return await pyserverFetchSortClaimsTree(
+  const {data, usage, cost} =  await pyserverFetchSortClaimsTree(
     `${env.PYSERVER_URL}/sort_claims_tree/`,
-    data,
+    input,
   )
     .then((res) => res.json())
     .then(logger("sort claims step returns: "))
     .then(apiPyserver.sortClaimsTreeResponse.parse);
+  return {data, usage, cost};
 }

--- a/express-server/src/pipeline/sortClaimsTree.ts
+++ b/express-server/src/pipeline/sortClaimsTree.ts
@@ -29,12 +29,12 @@ export async function sortClaimsTreePipelineStep(
   env: Env,
   input: SortClaimTreeStep["data"],
 ) {
-  const {data, usage, cost} =  await pyserverFetchSortClaimsTree(
+  const { data, usage, cost } = await pyserverFetchSortClaimsTree(
     `${env.PYSERVER_URL}/sort_claims_tree/`,
     input,
   )
     .then((res) => res.json())
     .then(logger("sort claims step returns: "))
     .then(apiPyserver.sortClaimsTreeResponse.parse);
-  return {data, usage, cost};
+  return { data, usage, cost };
 }

--- a/express-server/src/pipeline/topicTreeStep.ts
+++ b/express-server/src/pipeline/topicTreeStep.ts
@@ -27,7 +27,7 @@ export async function topicTreePipelineStep(
   env: Env,
   input: TopicTreeStep["data"],
 ) {
-  const { data, usage } = await pyserverFetchTopicTree(
+  const { data, usage, cost} = await pyserverFetchTopicTree(
     `${env.PYSERVER_URL}/topic_tree/`,
     input,
   )
@@ -35,5 +35,5 @@ export async function topicTreePipelineStep(
     .then(logger("topic tree step returns: "))
     .then(apiPyserver.topicTreeResponse.parse);
 
-  return { data, usage };
+  return { data, usage, cost};
 }

--- a/express-server/src/pipeline/topicTreeStep.ts
+++ b/express-server/src/pipeline/topicTreeStep.ts
@@ -27,7 +27,7 @@ export async function topicTreePipelineStep(
   env: Env,
   input: TopicTreeStep["data"],
 ) {
-  const { data, usage, cost} = await pyserverFetchTopicTree(
+  const { data, usage, cost } = await pyserverFetchTopicTree(
     `${env.PYSERVER_URL}/topic_tree/`,
     input,
   )
@@ -35,5 +35,5 @@ export async function topicTreePipelineStep(
     .then(logger("topic tree step returns: "))
     .then(apiPyserver.topicTreeResponse.parse);
 
-  return { data, usage, cost};
+  return { data, usage, cost };
 }

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -29,7 +29,9 @@ export function sumTokensCost(run: {
   run.tracker.prompt_tokens += run.stepUsage.prompt_tokens;
   run.tracker.completion_tokens += run.stepUsage.completion_tokens;
   run.tracker.total_tokens += run.stepUsage.total_tokens;
-  console.log(`Cost:$${run.tracker.costs};Tok_in:${run.tracker.prompt_tokens};Tok_out:${run.tracker.completion_tokens}`);
+  console.log(
+    `Cost:$${run.tracker.costs};Tok_in:${run.tracker.prompt_tokens};Tok_out:${run.tracker.completion_tokens}`,
+  );
 }
 
 const setupPipelineWorker = (connection: Redis) => {

--- a/pyserver/config.py
+++ b/pyserver/config.py
@@ -3,6 +3,21 @@
 # cheapest for testing 
 MODEL = "gpt-4o-mini" # prod default: "gpt-4-turbo-preview"
 
+COST_BY_MODEL = {
+  # GPT-4o mini: Input is $0.150 / 1M tokens, Output is $0.600 / 1M tokens
+  # or: input is $0.00015/1K tokens, output is $0.0006/1K tokens
+  "gpt-4o-mini" : {
+    "in_per_1K" : 0.00015,
+    "out_per_1K" : 0.0006
+  },
+  # GPT-4o : Input is $2.50 / 1M tokens, Output is $10.00/1M tokens
+  # or: input is $0.0025/1K tokens, output is $0.01/1K tokens
+  "gpt-4o" : {
+    "in_per_1K" : 0.0025,
+    "out_per_1K" : 0.01
+  }
+}
+
 SYSTEM_PROMPT = """
 You are a professional research assistant. You have helped run many public consultations,
 surveys and citizen assemblies. You have good instincts when it comes to extracting interesting insights.

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -33,7 +33,7 @@ current_dir = Path(__file__).resolve().parent
 sys.path.append(str(current_dir))
 
 import config
-from utils import cute_print, topic_desc_map, full_speaker_map
+from utils import cute_print, topic_desc_map, full_speaker_map, token_cost
 
 load_dotenv()
 
@@ -203,6 +203,8 @@ def comments_to_tree(req: CommentsLLMConfig, log_to_wandb:str = config.WANDB_GRO
     print("Step 1: no topic tree: ", response)
     tree = {}
   usage = response.usage
+  # compute LLM costs for this step's tokens
+  s1_total_cost = token_cost(req.llm.model_name, usage.prompt_tokens, usage.completion_tokens)
     
   if log_to_wandb:
     try:
@@ -236,13 +238,14 @@ def comments_to_tree(req: CommentsLLMConfig, log_to_wandb:str = config.WANDB_GRO
         # token counts
         "U_tok_N/taxonomy": usage.total_tokens,
         "U_tok_in/taxonomy" : usage.prompt_tokens,
-        "U_tok_out/taxonomy": usage.completion_tokens
+        "U_tok_out/taxonomy": usage.completion_tokens,
+        "cost/s1_topics" : s1_total_cost,
       })
     except:
       print("Failed to create wandb run")
   #NOTE:we could return a dictionary with one key "taxonomy", or the raw taxonomy list directly
   # choosing the latter for now 
-  return {"data" : tree["taxonomy"], "usage" : usage.model_dump()}
+  return {"data" : tree["taxonomy"], "usage" : usage.model_dump(), "cost" : s1_total_cost}
 
 def comment_to_claims(llm:dict, comment:str, tree:dict)-> dict:
   """
@@ -490,6 +493,9 @@ def all_comments_to_claims(req:CommentTopicTree, log_to_wandb:str = config.WANDB
                                              }
                                         }
                                       }
+  # compute LLM costs for this step's tokens
+  s2_total_cost = token_cost(req.llm.model_name, TK_2_IN, TK_2_OUT)
+
   # Note: we will now be sending speaker names to W&B  
   if log_to_wandb:
     try:
@@ -508,7 +514,8 @@ def all_comments_to_claims(req:CommentTopicTree, log_to_wandb:str = config.WANDB
         "U_tok_out/claims" : TK_2_OUT,
         "rows_to_claims" : wandb.Table(
                            data=comms_to_claims_html,
-                           columns = ["comments", "claims"])
+                           columns = ["comments", "claims"]),
+        "cost/s2_claims" : s2_total_cost
       })
     except:
       print("Failed to log wandb run")
@@ -516,7 +523,7 @@ def all_comments_to_claims(req:CommentTopicTree, log_to_wandb:str = config.WANDB
   net_usage = {"total_tokens" : TK_2_TOT,
                "prompt_tokens" : TK_2_IN,
                "completion_tokens" : TK_2_OUT}
-  return {"data" : node_counts, "usage" : net_usage}
+  return {"data" : node_counts, "usage" : net_usage, "cost" : s2_total_cost}
 
 def dedup_claims(claims:list, llm:LLMConfig)-> dict:
   """
@@ -915,6 +922,9 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = config.WANDB_GRO
   elif req.sort == "numClaims":
     full_sort_tree = sorted(sorted_tree.items(), key=lambda x: x[1]["counts"]["claims"], reverse=True)
  
+  # compute LLM costs for this step's tokens
+  s3_total_cost = token_cost(req.llm.model_name, TK_IN, TK_OUT)
+  
   if log_to_wandb:
     try:
       exp_group_name = str(log_to_wandb)
@@ -933,7 +943,8 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = config.WANDB_GRO
         "U_tok_in/dedup": TK_IN,
         "U_tok_out/dedup" : TK_OUT,
         "deduped_claims" : wandb.Table(data=dupe_logs, columns = ["full_flat_claims", "deduped_claims"]),
-        "t3c_report" : wandb.Table(data=report_data, columns = ["t3c_report"])
+        "t3c_report" : wandb.Table(data=report_data, columns = ["t3c_report"]),
+        "cost/s3_dedup" : s3_total_cost
       })
       # W&B run completion
       wandb.run.finish()
@@ -943,7 +954,7 @@ def sort_claims_tree(req:ClaimTreeLLMConfig, log_to_wandb:str = config.WANDB_GRO
                "prompt_tokens" : TK_IN,
                "completion_tokens" : TK_OUT}
 
-  return {"data" : full_sort_tree, "usage" : net_usage} 
+  return {"data" : full_sort_tree, "usage" : net_usage, "cost" : s3_total_cost} 
 
 ###########################################
 # Optional / New Feature & Research Steps #
@@ -1039,8 +1050,6 @@ def cruxes_for_topic(llm:dict, topic:str, topic_desc:str, claims:list, speaker_m
   except:
     crux_obj = crux
   return {"crux" : crux_obj, "usage" : response.usage }
-
-
 
 def top_k_cruxes(cont_mat:list, cruxes:list, top_k:int=0)->list:
   """ Return the top K most controversial crux pairs. 
@@ -1162,6 +1171,8 @@ def cruxes_from_tree(req:CruxesLLMConfig, log_to_wandb:str = config.WANDB_GROUP_
   crux_claims_only = [row[0] for row in crux_claims]
   top_cruxes = top_k_cruxes(full_controversy_matrix, crux_claims_only, req.top_k)
   print("Top cruxes: ", top_cruxes)
+  # compute LLM costs for this step's tokens
+  s4_total_cost = token_cost(req.llm.model_name, TK_IN, TK_OUT)
 
   # Note: we will now be sending speaker names to W&B
   # (still not to external LLM providers, to avoid bias on crux detection and better preserve PII)
@@ -1180,6 +1191,7 @@ def cruxes_from_tree(req:CruxesLLMConfig, log_to_wandb:str = config.WANDB_GROUP_
         "U_tok_N/cruxes" : TK_TOT,
         "U_tok_in/cruxes": TK_IN,
         "U_tok_out/cruxes" : TK_OUT,
+        "cost/s4_cruxes" : s4_total_cost,
         "crux_details" : wandb.Table(data=cruxes_main,
                                   columns=["crux", "reason", "agree", "disagree", "original_claims", "topic, subtopic", "description"]),
         "crux_top_scores" : wandb.Table(data=log_top_cruxes, columns=["score", "cruxA", "cruxB"])                           
@@ -1207,7 +1219,8 @@ def cruxes_from_tree(req:CruxesLLMConfig, log_to_wandb:str = config.WANDB_GROUP_
     "cruxClaims" : cruxes,
     "controversyMatrix" : full_controversy_matrix,
     "topCruxes" : top_cruxes,
-    "usage" : net_usage
+    "usage" : net_usage,
+    "cost" : s4_total_cost
   }
   return crux_response
 

--- a/pyserver/utils.py
+++ b/pyserver/utils.py
@@ -2,6 +2,16 @@
 import json
 import wandb
 
+import config
+
+def token_cost(model_name:str, tok_in:int, tok_out:int):
+  """ Returns the cost for the current model running the given numbers of
+  tokens in/out for this call """
+  if model_name not in config.COST_BY_MODEL:
+    print("model undefined!")
+    return -1
+  return 0.001 * (tok_in  *  config.COST_BY_MODEL[model_name]["in_per_1K"] + tok_out * config.COST_BY_MODEL[model_name]["out_per_1K"])
+
 def cute_print(json_obj):
   """Returns a pretty version of a dictionary as properly-indented and scaled
   json in html for at-a-glance review in W&B"""


### PR DESCRIPTION
TLDR: Sum and log the costs and token counts for each step of the LLM pipeline

We already have a "tracker" in workers.ts — I added a quick function to calculate the cost of each pipeline step and actually add that cost, and the associated token counts, to the tracker.
My goal was to implement this quickly — I very much welcome refactoring/cleanup for TS style (ideally as a PR on top of this cc @Brandon-Perry )

* calculate costs in pyserver, using a quick dictionary of prices per model and a utils function for the math (returns -1 if we use a model for which we don't yet store the price)
* return the cost of each LLM pipeline step from pyserver (and log to wandb when relevant)
* return the cost from the TS wrapper for each pipeline step
* in workers.ts, add a helper function that accumulates the total cost and token counts for each report generation, and log the new totals whenever it's called
