### PR TITLE
UX text polish: swap placeholder for helpful info; fix price estimate

### DIFF
--- a/next-client/src/components/create/CreateReport.tsx
+++ b/next-client/src/components/create/CreateReport.tsx
@@ -625,7 +625,7 @@ function CostEstimate({ files }: { files: FileList | undefined }) {
           This estimate is based on past reports. Typically, our real cost vary
           between by 10-15% up or down. A general guideline is that 1 MB costs
           approximately $24, so 0.5 MB would be around $12, and 10 MB about
-          $120.
+          $240.
         </p>
       </Col>
     </Col>

--- a/next-client/src/components/create/CreateReport.tsx
+++ b/next-client/src/components/create/CreateReport.tsx
@@ -335,7 +335,8 @@ function PoorlyFormattedModal({
             We detected a poorly formatted csv. Do you want to proceed?
           </AlertDialogTitle>
           <AlertDialogDescription>
-            Please make sure the CSV contains at least two columns named "id" and "comment"
+            Please make sure the CSV contains at least two columns named "id"
+            and "comment"
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/next-client/src/components/create/CreateReport.tsx
+++ b/next-client/src/components/create/CreateReport.tsx
@@ -332,9 +332,11 @@ function PoorlyFormattedModal({
       <AlertDialogContent className="w-[329px] gap-6">
         <AlertDialogHeader>
           <AlertDialogTitle>
-            We detected a poorly formatted csv. Do you want to proceed
+            We detected a poorly formatted csv. Do you want to proceed?
           </AlertDialogTitle>
-          <AlertDialogDescription>Lorem ipsum</AlertDialogDescription>
+          <AlertDialogDescription>
+            Please make sure the CSV contains at least two columns named "id" and "comment"
+          </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={cancelFunc} asChild>


### PR DESCRIPTION
1. What is the goal of this PR?
- remove some stale "lorem ipsum" placeholder text from an alert dialogue
- meta: make sure I made this PR template correctly

2. What changes does it introduce?
- corrects grammar and replaces "lorem ipsum" placeholder with more useful formatting advice

3. How did you test this PR?
- made sure I can run it locally
- to trigger this modal, try to upload a CSV file with one incorrect column name like the following
```
id,text
1,hello
2,world
```