### PR TITLE
minimal setup for cruxes checkbox

### DIFF
--- a/common/prompts.ts
+++ b/common/prompts.ts
@@ -81,6 +81,23 @@ And now, here are the claims:
 \${claims}
 `;
 
+export const defaultCruxPrompt = `
+I'm going to give you a topic with a description and a list of high-level claims about this topic made by different participants,
+identified by pseudonyms like "Person 1" or "A". I want you to formulate a new, specific statement called a "cruxClaim"
+which would best split the participants into two groups, based on all their
+statements on this topic: one group which would agree with the statement, and one which would disagree.
+Please explain your reasoning and assign participants into "agree" and "disagree" groups.
+return a JSON object of the form
+{
+  "crux" : {
+    "cruxClaim" : string // the new extracted claim
+    "agree" : list of strings // list of the given participants who would agree with the cruxClaim
+    "disagree" : list strings // list of the given participants who would disagree with the cruxClaim
+    "explanation" : string // reasoning for why you synthesized this cruxClaim from the participants' perspective
+  }
+}
+`;
+
 /**
  * Takes a prompt and data, and then inserts those values into the prompt.
  * The reason for this is that the string the user provides can't actually be a template literal.

--- a/common/schema.ts
+++ b/common/schema.ts
@@ -71,6 +71,7 @@ export const llmUserConfig = z.object({
   extractionInstructions: z.string().min(1),
   dedupInstructions: z.string().min(1),
   cruxInstructions: z.string().optional(),
+  cruxesEnabled: z.boolean().optional(),
 });
 
 export type LLMUserConfig = z.infer<typeof llmUserConfig>;
@@ -96,6 +97,7 @@ export const oldOptions = z.object({
   extractionInstructions: z.string(),
   dedupInstructions: z.string(),
   cruxInstructions: z.string().optional(),
+  cruxesEnabled: z.boolean().optional(),
   batchSize: z.number(),
   filename: z.string(),
   googleSheet: z

--- a/common/schema.ts
+++ b/common/schema.ts
@@ -71,7 +71,7 @@ export const llmUserConfig = z.object({
   extractionInstructions: z.string().min(1),
   dedupInstructions: z.string().min(1),
   cruxInstructions: z.string().optional(),
-  cruxesEnabled: z.boolean().optional(),
+  cruxesEnabled: z.boolean().optional().nullish().transform((val) => val ?? false)
 });
 
 export type LLMUserConfig = z.infer<typeof llmUserConfig>;
@@ -97,7 +97,7 @@ export const oldOptions = z.object({
   extractionInstructions: z.string(),
   dedupInstructions: z.string(),
   cruxInstructions: z.string().optional(),
-  cruxesEnabled: z.boolean().optional(),
+  cruxesEnabled: z.boolean().optional().nullish().transform((val) => val ?? false),
   batchSize: z.number(),
   filename: z.string(),
   googleSheet: z

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -171,6 +171,7 @@ const setupPipelineWorker = (connection: Redis) => {
       // us refer to the same tracker objects — open to more graceful solutions and
       // this is why I wanted to pass by reference ~S
       const tracker_crux = tracker_step2;
+      let cruxAddOns = {};
       if (options.cruxesEnabled === true) {
 
         console.log("Step 2.5: Optionally extract cruxes");

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -72,6 +72,7 @@ const setupPipelineWorker = (connection: Redis) => {
         extractionInstructions: "",
         dedupInstructions: "",
         cruxInstructions: "",
+        cruxesEnabled: false,
         batchSize: 2, // lower to avoid rate limits! initial was 10,
       };
 
@@ -83,6 +84,7 @@ const setupPipelineWorker = (connection: Redis) => {
       });
 
       const options: schema.OldOptions = { ...defaultConfig, ...config };
+      console.log("CRUX OPTIONS: ", options.cruxesEnabled);
 
       const [
         topicTreeLLMConfig,
@@ -163,6 +165,7 @@ const setupPipelineWorker = (connection: Redis) => {
         stepCost: claimsCost,
       });
       logTokensInTracker(tracker_step2);
+      console.log("CRUX OPTIONS: ", options.cruxesEnabled);
 
       console.log("Step 2.5: Optionally extract cruxes");
       const {

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -84,7 +84,6 @@ const setupPipelineWorker = (connection: Redis) => {
       });
 
       const options: schema.OldOptions = { ...defaultConfig, ...config };
-      console.log("CRUX OPTIONS: ", options.cruxesEnabled);
 
       const [
         topicTreeLLMConfig,
@@ -167,11 +166,10 @@ const setupPipelineWorker = (connection: Redis) => {
       logTokensInTracker(tracker_step2);
       console.log("user enabled crux extraction: ", options.cruxesEnabled);
 
-      // TODO: this catches the case where we DO NOT run Step 2.5 and lets
-      // us refer to the same tracker objects — open to more graceful solutions and
-      // this is why I wanted to pass by reference ~S
-      const tracker_crux = tracker_step2;
+      // TODO: more graceful way to catch the case where we don't run Step 2.5?
+      // perhaps we can pass by reference instead of renaming the tracker object?
       let cruxAddOns = {};
+      const tracker_crux = tracker_step2;
       if (options.cruxesEnabled === true) {
 
         console.log("Step 2.5: Optionally extract cruxes");

--- a/next-client/src/components/create/CreateReport.tsx
+++ b/next-client/src/components/create/CreateReport.tsx
@@ -49,6 +49,7 @@ import { User } from "firebase/auth";
 import { useFormStatus } from "react-dom";
 import { useRouter } from "next/navigation";
 import { signInWithGoogle } from "@/lib/firebase/auth";
+import { crux } from "tttc-common/schema";
 
 const fetchToken = async (
   user: User | null,
@@ -86,6 +87,8 @@ const form = z.object({
   clusteringInstructions: z.string().min(1),
   extractionInstructions: z.string().min(1),
   dedupInstructions: z.string().min(1),
+  cruxInstructions: z.string().optional(),
+  cruxesEnabled: z.boolean().optional(),
 });
 
 function Center({ children }: React.PropsWithChildren) {
@@ -180,6 +183,8 @@ function CreateReportComponent({ token }: { token: string | null }) {
       clusteringInstructions: prompts.defaultClusteringPrompt,
       extractionInstructions: prompts.defaultExtractionPrompt,
       dedupInstructions: prompts.defaultDedupPrompt,
+      cruxInstructions: prompts.defaultCruxPrompt,
+      cruxesEnabled: false,
     },
   });
 
@@ -206,6 +211,7 @@ function CreateReportComponent({ token }: { token: string | null }) {
             <FormDataInput files={files} setFiles={setFiles} />
             <CostEstimate files={files} />
             <AdvancedSettings />
+            <EnableResearchFeatures />
             <div>
               <Button size={"sm"} type="submit" disabled={isDisabled}>
                 Generate the report
@@ -565,6 +571,11 @@ const CustomizePrompts = ({ show }: { show: boolean }) => (
       subheader="In the last step, AI collects very similar or near-duplicate statements under one representative claim"
       inputName="dedupInstructions"
     />
+    <CustomizePromptSection
+      title="Optional – Suggest crux summary statements of opposing perspectives"
+      subheader="In this optional research step, AI suggests pairs of 'crux' statements which would best split participants into agree/disagree groups or sides of about equal size"
+      inputName="cruxInstructions"
+    />
   </Col>
 );
 
@@ -596,6 +607,42 @@ function AdvancedSettings() {
     </Col>
   );
 }
+
+const EnableResearchFeatures = () => {
+  const [areCruxesEnabled, setCruxesEnabled] = React.useState(false);
+  const handleChange = (event) => {
+    setCruxesEnabled((areCruxesEnabled) => !areCruxesEnabled);
+    console.log("ARE CRUXES ENABLED? : ", areCruxesEnabled.toString());
+  };
+  return (
+    <Col gap={4}>
+      <h4>Enable Research Features</h4>
+      <Col gap={2}>
+        <Col>
+          <label htmlFor="title" className="font-medium">
+            Extract likely crux statements
+          </label>
+          <p className="p2 text-muted-foreground">
+            As an extra processing step, suggest pairs of
+            perspective-summarizing statements which would best split the
+            respondents (into agree/disagree sides/groups of about equal size).
+          </p>
+          <div style={{ margin: "8px 0" }}>
+            <input
+              type="checkbox"
+              checked={areCruxesEnabled}
+              onChange={handleChange}
+            />
+            <label style={{ paddingLeft: "8px" }}>
+              Suggest top crux pairs
+              <p>Are cruxes enabled? {areCruxesEnabled.toString()}</p>
+            </label>
+          </div>
+        </Col>
+      </Col>
+    </Col>
+  );
+};
 
 function CustomizePromptSection({
   title,

--- a/next-client/src/components/create/CreateReport.tsx
+++ b/next-client/src/components/create/CreateReport.tsx
@@ -88,7 +88,7 @@ const form = z.object({
   extractionInstructions: z.string().min(1),
   dedupInstructions: z.string().min(1),
   cruxInstructions: z.string().optional(),
-  cruxesEnabled: z.boolean().optional(),
+  cruxesEnabled: z.boolean().optional().nullish().transform((val) => val ?? false)
 });
 
 function Center({ children }: React.PropsWithChildren) {
@@ -211,7 +211,6 @@ function CreateReportComponent({ token }: { token: string | null }) {
             <FormDataInput files={files} setFiles={setFiles} />
             <CostEstimate files={files} />
             <AdvancedSettings />
-            <EnableResearchFeatures />
             <div>
               <Button size={"sm"} type="submit" disabled={isDisabled}>
                 Generate the report
@@ -542,6 +541,7 @@ const FormOpenAIKey = () => {
 
 const CustomizePrompts = ({ show }: { show: boolean }) => (
   <Col gap={8} className={show ? "" : "hidden"}>
+    <EnableResearchFeatures/>
     <Col gap={4}>
       <h4>Customize AI prompts</h4>
       <p className="p2 text-muted-foreground">
@@ -612,7 +612,6 @@ const EnableResearchFeatures = () => {
   const [areCruxesEnabled, setCruxesEnabled] = React.useState(false);
   const handleChange = (event) => {
     setCruxesEnabled((areCruxesEnabled) => !areCruxesEnabled);
-    console.log("ARE CRUXES ENABLED? : ", areCruxesEnabled.toString());
   };
   return (
     <Col gap={4}>
@@ -626,6 +625,9 @@ const EnableResearchFeatures = () => {
             As an extra processing step, suggest pairs of
             perspective-summarizing statements which would best split the
             respondents (into agree/disagree sides/groups of about equal size).
+            This optional step increases processing costs and will only be run if you
+            check this box. Results are available in the JSON download at
+            the end of a report.
           </p>
           <div style={{ margin: "8px 0" }}>
             <input
@@ -635,7 +637,6 @@ const EnableResearchFeatures = () => {
             />
             <label style={{ paddingLeft: "8px" }}>
               Suggest top crux pairs
-              <p>Are cruxes enabled? {areCruxesEnabled.toString()}</p>
             </label>
           </div>
         </Col>

--- a/next-client/src/features/submission/actions/SubmitAction.ts
+++ b/next-client/src/features/submission/actions/SubmitAction.ts
@@ -34,21 +34,6 @@ export default async function submitAction(
     throw new Error("Missing data. Check your csv file");
   }
 
-  const tempCruxInstructions = `I'm going to give you a topic with a description and a list of high-level claims about this topic made by different participants,
-  identified by pseudonyms like "Person 1" or "A". I want you to formulate a new, specific statement called a "cruxClaim"
-  which would best split the participants into two groups, based on all their
-  statements on this topic: one group which would agree with the statement, and one which would disagree.
-  Please explain your reasoning and assign participants into "agree" and "disagree" groups.
-  return a JSON object of the form
-  {
-    "crux" : {
-      "cruxClaim" : string // the new extracted claim
-      "agree" : list of strings // list of the given participants who would agree with the cruxClaim
-      "disagree" : list strings // list of the given participants who would disagree with the cruxClaim
-      "explanation" : string // reasoning for why you synthesized this cruxClaim from the participants' perspective
-    }
-  }
-  `;
   const config: LLMUserConfig = llmUserConfig.parse({
     apiKey: formData.get("apiKey"),
     title: formData.get("title"),
@@ -58,7 +43,8 @@ export default async function submitAction(
     systemInstructions: formData.get("systemInstructions"),
     extractionInstructions: formData.get("extractionInstructions"),
     dedupInstructions: formData.get("dedupInstructions"),
-    cruxInstructions: tempCruxInstructions,
+    cruxInstructions: formData.get("cruxInstructions"),
+    cruxesEnabled: formData.get("cruxesEnabled"),
   });
   const dataPayload: DataPayload = ["csv", data];
 


### PR DESCRIPTION
**1. What is the goal of this PR?**
- Add a checkbox in createReport which controls if we run the crux step
- Only run the crux step if the user checks the box
- Let users customize the crux step prompt in advanced settings 

**2. What specific parts of T3C are you changing and how?**
- Input form: adds a checkbox
- Makes the crux step of the pipeline optional

**3. How did you test these changes?**
- tested and seems to work locally (could use a bit more testing once we fix/mock LLM calls)

Most interested in any more graceful ways to:
- let zod accept a boolean that can be null: I ended up with the following, maybe this could be simpler? `z.boolean().optional().nullish().transform((val) => val ?? false)`
- define cruxesEnabled in one place in the code instead of three as I am currently doing — maybe only one is necessary/this is code we can clean up?
- run the optional step in workers.ts without defining dummy variables

