### PR TITLE
Move all key transport to headers

### DIFF
--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -12,10 +12,14 @@ const llmConfig = z.object(
     model_name: z.string(),
     system_prompt: z.string(),
     user_prompt: z.string(),
-    api_key: z.string(),
   },
   { invalid_type_error: "Invalid llmConfig" },
 );
+
+/**
+ * Header name for OpenAI API key
+ */
+export const OPENAI_API_KEY_HEADER = "X-OpenAI-API-Key";
 
 export type LLMConfig = z.infer<typeof llmConfig>;
 

--- a/common/schema.ts
+++ b/common/schema.ts
@@ -63,7 +63,6 @@ export const llmPieChart = z.object({
 export type LLMPieChart = z.infer<typeof llmPieChart>;
 
 export const llmUserConfig = z.object({
-  // apiKey: z.string().optional(),
   title: z.string().min(1),
   description: z.string().min(1),
   systemInstructions: z.string().min(1),
@@ -85,7 +84,6 @@ export type oldSystemConfig = z.infer<typeof llmSystemConfig>;
 
 export const oldOptions = z.object({
   model: z.string(),
-  apiKey: z.string(),
   data: sourceRow.array(),
   title: z.string(),
   question: z.string(),

--- a/express-server/src/pipeline/claimsStep.ts
+++ b/express-server/src/pipeline/claimsStep.ts
@@ -3,6 +3,7 @@ import { ClaimsStep } from "./types";
 import { Env } from "../types/context";
 import { Client } from "undici";
 import { AbortController } from "abort-controller"; // If needed in your environment
+
 export async function claimsPipelineStep(env: Env, input: ClaimsStep["data"]) {
   try {
     //console.log("Claims pipeline input:", JSON.stringify(input));
@@ -39,6 +40,7 @@ export async function claimsPipelineStep(env: Env, input: ClaimsStep["data"]) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          [apiPyserver.OPENAI_API_KEY_HEADER]: env.OPENAI_API_KEY,
         },
         body: JSON.stringify(input),
         //signal: controller.signal,

--- a/express-server/src/pipeline/cruxesStep.ts
+++ b/express-server/src/pipeline/cruxesStep.ts
@@ -5,12 +5,13 @@ import { z } from "zod";
 
 const typedFetch =
   <T extends z.ZodTypeAny>(bodySchema: T) =>
-  async (url: string, body: z.infer<T>) =>
+  async (url: string, body: z.infer<T>, apiKey: string) =>
     await fetch(url, {
       method: "post",
       body: JSON.stringify(bodySchema.parse(body) as z.infer<T>),
       headers: {
         "Content-Type": "application/json",
+        [apiPyserver.OPENAI_API_KEY_HEADER]: apiKey,
       },
     });
 
@@ -25,7 +26,7 @@ const logger =
 
 export async function cruxesPipelineStep(env: Env, input: CruxesStep["data"]) {
   const { cruxClaims, controversyMatrix, topCruxes, usage, cost } =
-    await pyserverFetchClaims(`${env.PYSERVER_URL}/cruxes`, input)
+    await pyserverFetchClaims(`${env.PYSERVER_URL}/cruxes`, input, env.OPENAI_API_KEY)
       .then((res) => res.json())
       .then(logger("cruxes step returns: "))
       .then(apiPyserver.cruxesResponse.parse);

--- a/express-server/src/pipeline/sortClaimsTree.ts
+++ b/express-server/src/pipeline/sortClaimsTree.ts
@@ -5,12 +5,13 @@ import { z } from "zod";
 
 const typedFetch =
   <T extends z.ZodTypeAny>(bodySchema: T) =>
-  async (url: string, body: z.infer<T>) =>
+  async (url: string, body: z.infer<T>, apiKey: string) =>
     await fetch(url, {
       method: "PUT",
       body: JSON.stringify(bodySchema.parse(body) as z.infer<T>),
       headers: {
         "Content-Type": "application/json",
+        [apiPyserver.OPENAI_API_KEY_HEADER]: apiKey,
       },
     });
 
@@ -32,6 +33,7 @@ export async function sortClaimsTreePipelineStep(
   const { data, usage, cost } = await pyserverFetchSortClaimsTree(
     `${env.PYSERVER_URL}/sort_claims_tree`,
     input,
+    env.OPENAI_API_KEY,
   )
     .then((res) => res.json())
     .then(logger("sort claims step returns: "))

--- a/express-server/src/routes/create.ts
+++ b/express-server/src/routes/create.ts
@@ -8,6 +8,7 @@ import { formatData, uniqueSlug } from "../utils";
 import { pipelineQueue } from "../server";
 import * as firebase from "../Firebase";
 import { DecodedIdToken } from "firebase-admin/auth";
+import * as apiPyserver from "tttc-common/apiPyserver";
 
 const handleGoogleSheets = async (
   googleData: schema.GoogleSheetData,
@@ -77,7 +78,7 @@ const useAnonymousNames = (numOfEmptyInterviewRows: number) => {
 
 async function createNewReport(req: Request, res: Response) {
   const { env } = req.context;
-  const { CLIENT_BASE_URL, OPENAI_API_KEY, OPENAI_API_KEY_PASSWORD } = env;
+  const { CLIENT_BASE_URL, OPENAI_API_KEY } = env;
   const body = api.generateApiRequest.parse(req.body);
   const { data, userConfig, firebaseAuthToken } = body;
   // ! Temporary size check
@@ -128,19 +129,12 @@ async function createNewReport(req: Request, res: Response) {
     CLIENT_BASE_URL,
   ).toString();
 
-  // if user provided key is the same as our password, let them use our key
-  // const apiKey =
-  //   userConfig.apiKey === OPENAI_API_KEY_PASSWORD
-  //     ? OPENAI_API_KEY
-  //     : userConfig.apiKey;
-  const apiKey = OPENAI_API_KEY;
   // ! FIX
   // @ts-ignore
   const config: schema.OldOptions = {
     ...userConfig,
     ...parsedData,
     filename,
-    apiKey,
   };
 
   const response: api.GenerateApiResponse = {

--- a/next-client/src/features/submission/actions/SubmitAction.ts
+++ b/next-client/src/features/submission/actions/SubmitAction.ts
@@ -9,6 +9,7 @@ import Papa from "papaparse";
 import { GenerateApiResponse, GenerateApiRequest } from "tttc-common/api";
 import { z } from "zod";
 import { validatedServerEnv } from "@/server-env";
+import * as apiPyserver from "tttc-common/apiPyserver";
 
 const parseCSV = async (file: File): Promise<SourceRow[]> => {
   const buffer = await file.arrayBuffer();
@@ -50,7 +51,6 @@ export default async function submitAction(
   }
   `;
   const config: LLMUserConfig = llmUserConfig.parse({
-    apiKey: formData.get("apiKey"),
     title: formData.get("title"),
     // question: formData.get("question"),
     description: formData.get("description"),
@@ -75,6 +75,7 @@ export default async function submitAction(
     body: JSON.stringify(body),
     headers: {
       "Content-Type": "application/json",
+      [apiPyserver.OPENAI_API_KEY_HEADER]: formData.get("apiKey") as string,
     },
   });
   if (!response.ok) {


### PR DESCRIPTION
**1. What is the goal of this PR?**
This PR standardizes API key handling across T3C by moving all API key authentication to HTTP headers. This improves security by following best practices for sensitive credential handling and ensures consistent authentication across all components.


**2. What specific parts of T3C are you changing and how?**

Schema Changes (common/schema.ts):
- Removed apiKey from llmUserConfig schema
- Removed apiKey from oldOptions schema

Express Server Changes (express-server/src/routes/create.ts):
- Removed API key from request body
- Removed API key password check
- Removed API key from config object

Next.js Client Changes (next-client/src/features/submission/actions/SubmitAction.ts):
- Removed API key from llmUserConfig parsing
- Added API key to request headers using OPENAI_API_KEY_HEADER
- Added necessary import for header constant


**3. How did you test these changes?**

Runs locally, have not yet tested end to end to make sure everything is transported correctly because I think we're not using our open API key right now?
