### PR TITLE
don't fail on empty comments / speakers in input CSVs

### DIFF
--- a/common/apiPyserver.ts
+++ b/common/apiPyserver.ts
@@ -47,7 +47,7 @@ export type Usage = z.infer<typeof usage>;
  */
 const comment = z.object({
   id: z.string(),
-  text: z.string().min(1, "Empty comment"),
+  text: z.string(),
   speaker: z.string(),
 });
 

--- a/examples/sample_csv_files/missing_fields_pets.csv
+++ b/examples/sample_csv_files/missing_fields_pets.csv
@@ -1,6 +1,8 @@
 id,interview,comment
 1,Dany,
 2,,I love cats
+3,,Dogs are the most beautiful creatures especially when they look like wolves with the piercing blue eyes and gray tufts of hair on the ears. Or maybe those are squirrels.
+4,,Hummingbirds or owls nesting is my favorite dynamic to observe though they're not exactly domestic pets. They are both majestic!
 5,Eve,!
 6,Fiona,😂
 8,,
@@ -11,5 +13,6 @@ id,interview,comment
 13,Jack,I love cats
 14,Kate,maybe
 15,Lily,extremelyabsolutely
-16,Melody,idk
-17,Nancy,I don't know about that
+16,,Birds are underappreciated as pets though it's tricky to consider clipping their wings or pytting them in a cage.
+17,Melody,idk
+18,Nancy,I don't know about that

--- a/examples/sample_csv_files/missing_fields_pets.csv
+++ b/examples/sample_csv_files/missing_fields_pets.csv
@@ -1,0 +1,8 @@
+id,interview,comment
+1,Dany,
+2,,I love cats
+5,Eve,!
+6,Fiona,😂
+8,,
+9,,?
+10,Joy,Yes please

--- a/examples/sample_csv_files/missing_fields_pets.csv
+++ b/examples/sample_csv_files/missing_fields_pets.csv
@@ -6,3 +6,10 @@ id,interview,comment
 8,,
 9,,?
 10,Joy,Yes please
+11,Helen,Dogs rule
+12,George,I like it
+13,Jack,I love cats
+14,Kate,maybe
+15,Lily,extremelyabsolutely
+16,Melody,idk
+17,Nancy,I don't know about that

--- a/examples/sample_csv_files/speaker_pets.csv
+++ b/examples/sample_csv_files/speaker_pets.csv
@@ -1,0 +1,4 @@
+id,interview,comment
+1,Alice,I love cats
+2,Bob,I really really love dogs
+3,Charles,I am not sure about birds

--- a/express-server/src/routes/create.ts
+++ b/express-server/src/routes/create.ts
@@ -88,7 +88,8 @@ async function createNewReport(req: Request, res: Response) {
   }
   const _parsedData = await parseData(data);
   const makeAnonName = useAnonymousNames(
-    _parsedData.data.filter((x) => x.interview === undefined).length,
+    //NOTE: this check used to be for x.interview === undefined
+    _parsedData.data.filter((x) => !x.interview).length,
   );
   // Add anonymous names if interview prop is undefined
   const parsedData: {

--- a/express-server/src/workers.ts
+++ b/express-server/src/workers.ts
@@ -113,11 +113,12 @@ const setupPipelineWorker = (connection: Redis) => {
         }));
       console.log("input comment row count: ", comments.length);
 
-      if (comments.some((x) => !x.speaker)) {
-        throw new Error(
-          "Worker expects input data to include interview col to be filled out",
-        );
-      }
+      // TODO: this needs to be skipped / called later to allow for anonymous speakers
+      //if (comments.some((x) => !x.speaker)) {
+      //   throw new Error(
+      //    "Worker expects input data to include interview col to be filled out",
+      //  );
+      //}
 
       console.log("Step 1: generating taxonomy of topics and subtopics");
       await job.updateProgress({

--- a/pyserver/config.py
+++ b/pyserver/config.py
@@ -19,6 +19,9 @@ COST_BY_MODEL = {
     "gpt-4o": {"in_per_1K": 0.0025, "out_per_1K": 0.01},
 }
 
+# for web-app mode, require at least 3 words in order to extract meaningful claims
+MIN_WORD_COUNT_FOR_MEANING = 3
+
 SYSTEM_PROMPT = """
 You are a professional research assistant. You have helped run many public consultations,
 surveys and citizen assemblies. You have good instincts when it comes to extracting interesting insights.

--- a/pyserver/config.py
+++ b/pyserver/config.py
@@ -21,6 +21,7 @@ COST_BY_MODEL = {
 
 # for web-app mode, require at least 3 words in order to extract meaningful claims
 MIN_WORD_COUNT_FOR_MEANING = 3
+MIN_CHAR_COUNT_FOR_MEANING = 10
 
 SYSTEM_PROMPT = """
 You are a professional research assistant. You have helped run many public consultations,

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -33,7 +33,7 @@ from pydantic import BaseModel
 current_dir = Path(__file__).resolve().parent
 sys.path.append(str(current_dir))
 import config
-from utils import cute_print, full_speaker_map, token_cost, topic_desc_map
+from utils import cute_print, full_speaker_map, token_cost, topic_desc_map, comment_is_meaningful
 
 load_dotenv()
 
@@ -188,10 +188,10 @@ def comments_to_tree(
     full_prompt = req.llm.user_prompt
     for comment in req.comments:
         # skip any empty comments/rows
-        if len(comment.text) > 0:
+        if comment_is_meaningful(comment.text):
             full_prompt += "\n" + comment.text
         else:
-            print("warning:empty comment in topic_tree")
+            print("warning:empty comment in topic_tree:" + comment.text)
 
     response = client.chat.completions.create(
         model=req.llm.model_name,
@@ -438,10 +438,10 @@ def all_comments_to_claims(
         # TODO: timing for comments
         # print("comment: ", i_c)
         # print("time: ", datetime.now())
-        if len(comment.text) > 0:
+        if comment_is_meaningful(comment.text):
             response = comment_to_claims(req.llm, comment.text, req.tree)
         else:
-            print("warning: empty comment in claims")
+            print("warning: empty comment in claims:" + comment.text)
             continue
         try:
             claims = response["claims"]

--- a/pyserver/utils.py
+++ b/pyserver/utils.py
@@ -9,7 +9,7 @@ def comment_is_meaningful(raw_comment:str):
   to be meaningful in web app mode. Only check word count for short comments.
   TODO: add config for other modes like elicitation/direct response
   """
-  if len(raw_comment) > 10 or len(raw_comment.split(" ")) >= config.MIN_WORD_COUNT_FOR_MEANING:
+  if len(raw_comment) >= config.MIN_CHAR_COUNT_FOR_MEANING or len(raw_comment.split(" ")) >= config.MIN_WORD_COUNT_FOR_MEANING:
     return True
   else:
     return False

--- a/pyserver/utils.py
+++ b/pyserver/utils.py
@@ -4,6 +4,17 @@ import wandb
 
 import config
 
+def comment_is_meaningful(raw_comment:str):
+  """ Check whether the raw comment contains enough words/characters
+  to be meaningful in web app mode. Only check word count for short comments.
+  TODO: add config for other modes like elicitation/direct response
+  """
+  if len(raw_comment) > 10 or len(raw_comment.split(" ")) >= config.MIN_WORD_COUNT_FOR_MEANING:
+    return True
+  else:
+    return False
+
+
 def token_cost(model_name:str, tok_in:int, tok_out:int):
   """ Returns the cost for the current model running the given numbers of
   tokens in/out for this call """


### PR DESCRIPTION
**1. What is the goal of this PR?**
Currently we fail a whole report if any comment is empty. There's also a regression where we fail in workers.ts if a speaker name is not provided / interview column is empty. This draft PR fixes these issues & unblocks immediate generation of reports for CSVs with missing comments or speakers, but there may be more graceful solutions or other edge cases we don't handle yet.
Also added two of my standard test CSVs to examples/sample_csv_data.

**2. What specific parts of T3C are you changing and how?**
- remove requirement for comments to be at least 1 character in schema.ts since users often upload CSVs with some blank rows (empty "comment" fields)
- check for empty comments in pyserver and only call an LLM on one character or more—NOTE, we may want to revisit this and require at least 3-4 characters or even at least a sentence for the extracted claims to be meaningful and not hallucinated
- temporarily remove check on empty speaker in workers.ts — if we do this, we need to do it LATER/after anonymous names are added

**3. How did you test these changes?**
Locally