### PR TITLE
Open Graph for home page. 

### DIFF
--- a/next-client/src/app/layout.tsx
+++ b/next-client/src/app/layout.tsx
@@ -3,11 +3,47 @@ import Navbar from "@/components/navbar/Navbar";
 import { Toaster } from "@/components/elements";
 import "./global.css";
 import { getAuthenticatedAppForUser } from "@/lib/firebase/serverApp";
+import { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Talk to the City",
+  openGraph: {
+    title: "Talk to the City",
+    description:
+      "Talk to the City helps large groups of people coordinate by understanding each other better, faster, and in more depth.",
+    siteName: "Talk to the City",
+    images: [
+      {
+        url: "/images/t3c-product-desktop-mobile.png",
+        width: 1200,
+        height: 630,
+        alt: "Talk to the city",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Talk to the City",
+    description:
+      "Talk to the City helps large groups of people coordinate by understanding each other better, faster, and in more depth.",
+    creator: "@AIObjectives",
+    images: [
+      new URL(
+        process.env.NODE_ENV === "development"
+          ? "http://localhost:3000/images/t3c-product-desktop-mobile.png"
+          : "https://www.talktothe.city/images/t3c-product-desktop-mobile.png",
+      ),
+    ],
+  },
+  metadataBase: new URL(
+    process.env.NODE_ENV === "development"
+      ? "localhost:3000"
+      : "https://www.talktothe.city",
+  ),
 };
 
 export default async function RootLayout({
@@ -27,17 +63,7 @@ export default async function RootLayout({
           <Navbar currentUser={currentUser} />
           {children}
         </div>
-        <Toaster
-          position="bottom-right"
-          // toastOptions={{
-          //   className: "border-none p-4 flex",
-          //   classNames: {
-          //     toast: "bg-accent",
-          //     title: "text-accent-foreground",
-          //     icon: "text-accent-foreground",
-          //   },
-          // }}
-        />
+        <Toaster position="bottom-right" />
       </body>
     </html>
   );


### PR DESCRIPTION
**1. What is the goal of this PR?**

Adds an open graph preview to our next client's metadata so that when its shared on a social media site, it has the correct preview.

**2. What specific parts of T3C are you changing and how?**

root layout of nextjs client


**3. How did you test these changes?**

I used a GC plugin to see the previews. Here they are:

![image](https://github.com/user-attachments/assets/0995e139-3179-4742-b188-14db4b047642)

![image](https://github.com/user-attachments/assets/97394606-a851-474e-b7fe-a3586fa05309)

![image](https://github.com/user-attachments/assets/66592ed1-c019-43d4-a53a-93814f3793a5)

**One potential issue: **
The image looks like very top part of the preview image is being clipped. @colleenm How does this look to you? If you want it changed, I think we'll need to change the image itself to be a different aspect ratio. 


Also, I think we should add an open graph preview to each report that's generated. However, I need to change it so that our report data is being fetched server side first. I'm going to throw those tickets into Trello. @justinstimatze 

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
