### PR TITLE
T3C-155: Fix express-rate-limit 'trust proxy' setting

### DIFF
--- a/express-server/src/server.ts
+++ b/express-server/src/server.ts
@@ -15,6 +15,10 @@ const env = validateEnv();
 
 const app = express();
 app.use(cors());
+ // Required to use express-rate-limit with CloudRun, but doesn't apply to local
+ if (process.env.NODE_ENV === "production") { // Could be its own env var, but correct for now.
+  app.set('trust proxy', 1);
+}
 app.use(express.json({ limit: "50mb" }));
 app.use(express.static("public"));
 


### PR DESCRIPTION
**1. What is the goal of this PR?**

Fix a staging bug where the new rate limiter wasn't working with CloudRun.

**2. What specific parts of T3C are you changing and how?**

express-server app settings.

**3. How did you test these changes?**

Pushed rebuilt containers to staging, confirmed fixed.


Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
