### PR TITLE
T3C-249: Refine firebase usage across client and server

### DIFF
--- a/next-client/src/app/create/page.tsx
+++ b/next-client/src/app/create/page.tsx
@@ -1,8 +1,19 @@
 "use client";
 import CreateReport from "@/components/create/CreateReport";
+import { useUser } from "@/lib/hooks/getUser";
 import React from "react";
 
 export default function ReportCreationPage() {
+  const user = useUser();
+
+  if (user === null) {
+    return (
+      <div className="w-full h-full content-center justify-items-center">
+        <p>Please login to create a report</p>
+      </div>
+    );
+  }
+
   return (
     <div className="m-auto max-w-[832px] p-2 mt-4">
       <CreateReport />

--- a/next-client/src/app/layout.tsx
+++ b/next-client/src/app/layout.tsx
@@ -2,7 +2,6 @@ import { nextTypography } from "@/lib/font";
 import Navbar from "@/components/navbar/Navbar";
 import { Toaster } from "@/components/elements";
 import "./global.css";
-import { getAuthenticatedAppForUser } from "@/lib/firebase/serverApp";
 import { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
@@ -51,7 +50,6 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { currentUser } = await getAuthenticatedAppForUser();
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -60,7 +58,7 @@ export default async function RootLayout({
       <body className={nextTypography}>
         <script src="index.js"></script>
         <div className="h-screen w-screen">
-          <Navbar currentUser={currentUser} />
+          <Navbar />
           {children}
         </div>
         <Toaster position="bottom-right" />

--- a/next-client/src/app/my-reports/page.tsx
+++ b/next-client/src/app/my-reports/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 import { useUser } from "@/lib/hooks/getUser";
-import { getUsersReports } from "../../lib/firebase/firestore";
-import { db } from "@/lib/firebase/clientApp";
+import { getUsersReports } from "../../lib/firebase/firestoreClient";
+import { getFirebaseDb } from "@/lib/firebase/clientApp";
 import { useAsyncState } from "@/lib/hooks/useAsyncState";
 import { useEffect, useState } from "react";
 import MyReports from "@/components/myReports/MyReports";
 import { Spinner } from "@/components/elements";
+
+const db = getFirebaseDb();
 
 function Center({ children }: React.PropsWithChildren) {
   return (

--- a/next-client/src/components/create/CreateReport.tsx
+++ b/next-client/src/components/create/CreateReport.tsx
@@ -49,17 +49,7 @@ import { User } from "firebase/auth";
 import { useFormStatus } from "react-dom";
 import { useRouter } from "next/navigation";
 import { signInWithGoogle } from "@/lib/firebase/auth";
-
-const fetchToken = async (
-  user: User | null,
-): Promise<["data", string | null] | ["error", string]> => {
-  try {
-    if (!user) return ["data", null];
-    return ["data", await user?.getIdToken()];
-  } catch (e) {
-    return ["error", e instanceof Error ? e.message : "An error occured"];
-  }
-};
+import { fetchToken } from "@/lib/firebase/getIdToken";
 
 function getUserToken() {
   const user = useUser();
@@ -108,10 +98,15 @@ export default function CreateReport() {
   else if (result[0] === "error")
     return (
       <Center>
-        <p>An error occured...</p>
+        <p>An error occurred...</p>
       </Center>
     );
-  else return <CreateReportComponent token={result[1]} />;
+  else {
+    if (result[0] === "data" && typeof result[1] === "string") {
+      // Safe to use result[1] as a token
+      return <CreateReportComponent token={result[1]} />;
+    }
+  }
 }
 
 const SigninModal = ({ isOpen }: { isOpen: boolean }) => {

--- a/next-client/src/components/navbar/Navbar.tsx
+++ b/next-client/src/components/navbar/Navbar.tsx
@@ -11,7 +11,7 @@ import {
 import LoginButton from "./components/LoginButton";
 import { User } from "firebase/auth";
 
-function Navbar({ currentUser }: { currentUser: User | null }) {
+function Navbar() {
   return (
     <Row
       gap={6}
@@ -36,7 +36,7 @@ function Navbar({ currentUser }: { currentUser: User | null }) {
 
         <CreateReport />
 
-        <LoginButton currentUser={currentUser} />
+        <LoginButton />
       </Row>
     </Row>
   );

--- a/next-client/src/components/navbar/components/LoginButton.tsx
+++ b/next-client/src/components/navbar/components/LoginButton.tsx
@@ -17,8 +17,8 @@ import {
 } from "@/lib/firebase/auth";
 import { User } from "firebase/auth";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useUser } from "@/lib/hooks/getUser";
 
 const getInitials = (name: string) =>
   name
@@ -26,49 +26,14 @@ const getInitials = (name: string) =>
     .map((word) => word[0])
     .join("");
 
-/**
- * @fileoverview LoginButton component + some user session management logic.
- *
- * TODO: There is flickering present
- */
-
-/**
- * Hook for managing a user session
- */
-function useUserSession(initialUser: User | null): [boolean, User | null] {
-  // The initialUser comes from the server via a server component
-  const [user, setUser] = useState(initialUser);
-  const [authLoading, setAuthLoading] = useState<boolean>(true);
-  const router = useRouter();
+export default function LoginButton() {
+  const user = useUser();
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged((authUser) => {
-      setUser(authUser);
-      setAuthLoading(false);
-    });
-
-    return () => unsubscribe();
-  }, []);
-
-  useEffect(() => {
-    onAuthStateChanged((authUser) => {
-      if (user === undefined) return;
-
-      if (user?.email !== authUser?.email) {
-        router.refresh();
-      }
-    });
+    setLoading(false);
   }, [user]);
 
-  return [authLoading, user];
-}
-
-export default function LoginButton({
-  currentUser,
-}: {
-  currentUser: User | null;
-}) {
-  const [loading, user] = useUserSession(currentUser);
   if (loading) {
     return (
       <div>

--- a/next-client/src/lib/firebase/auth.ts
+++ b/next-client/src/lib/firebase/auth.ts
@@ -1,3 +1,16 @@
+/**
+ * Firebase Authentication (Client SDK)
+ *
+ * Handles user authentication in the browser using Firebase Auth.
+ * This runs on the client side and manages user sign-in/sign-out flows.
+ *
+ * The client SDK authentication:
+ * - Provides UI-based auth flows (Google popup, etc.)
+ * - Manages auth state in the browser
+ * - Generates ID tokens that can be sent to server
+ * - Handles token refresh automatically
+ */
+
 import {
   GoogleAuthProvider,
   signInWithPopup,
@@ -6,12 +19,21 @@ import {
   browserLocalPersistence,
 } from "firebase/auth";
 
-import { auth } from "./clientApp";
+import { getFirebaseAuth } from "./clientApp";
+const auth = getFirebaseAuth();
 
+/**
+ * Listen for authentication state changes.
+ * This is how React components stay in sync with auth state.
+ */
 export function onAuthStateChanged(cb) {
   return _onAuthStateChanged(auth, cb);
 }
 
+/**
+ * Sign in with Google using a popup window.
+ * Sets persistence to local storage so user stays signed in across browser sessions.
+ */
 export async function signInWithGoogle() {
   const provider = new GoogleAuthProvider();
   // Add scopes here if we need access to user data
@@ -25,6 +47,10 @@ export async function signInWithGoogle() {
   }
 }
 
+/**
+ * Sign out the current user.
+ * Clears auth state and tokens from the browser.
+ */
 export async function signOut() {
   try {
     return auth.signOut();

--- a/next-client/src/lib/firebase/clientApp.ts
+++ b/next-client/src/lib/firebase/clientApp.ts
@@ -1,3 +1,28 @@
+/**
+ * Firebase Client SDK Setup
+ *
+ * This file initializes the Firebase Client SDK which runs in the browser.
+ * The client SDK is used for:
+ * - User authentication (sign in/out)
+ * - Real-time database operations from the browser
+ * - Client-side security rules enforcement
+ * - Offline capabilities
+ *
+ * Key differences from server SDK:
+ * - Runs in browser environment with limited privileges
+ * - Authentication happens through user login flows
+ * - Security rules are enforced by Firebase servers
+ * - Can work offline and sync when reconnected
+ *
+ * IMPORTANT: Functions vs Direct Initialization
+ * We use functions to access Firebase services instead of initializing them
+ * at module load time because:
+ * 1. Environment variables are loaded at runtime, not compile time
+ * 2. Next.js may not have process.env populated when this module first loads
+ * 3. Different deployment environments (dev/staging/prod) need different configs
+ * 4. Lazy initialization ensures credentials are available when actually needed
+ */
+
 "use client";
 
 import { initializeApp, getApps } from "firebase/app";
@@ -5,8 +30,41 @@ import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 import { firebaseConfig } from "./config";
-export const firebaseApp =
-  getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
-export const auth = getAuth(firebaseApp);
-export const db = getFirestore(firebaseApp);
-export const storage = getStorage(firebaseApp);
+
+let firebaseApp: ReturnType<typeof initializeApp> | undefined;
+
+/**
+ * Get or create the Firebase app instance for client-side use.
+ * Ensures only one app instance exists (singleton pattern).
+ * Multiple instances can supposedly complicate state.
+ */
+export function getFirebaseApp() {
+  if (!firebaseApp) {
+    firebaseApp =
+      getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+  }
+  return firebaseApp;
+}
+
+/**
+ * Get Firebase Auth instance for client-side authentication.
+ * Handles user sign-in/sign-out and auth state management.
+ */
+export function getFirebaseAuth() {
+  return getAuth(getFirebaseApp());
+}
+
+/**
+ * Get Firestore database instance for client-side operations.
+ * All operations go through Firebase security rules.
+ */
+export function getFirebaseDb() {
+  return getFirestore(getFirebaseApp());
+}
+
+/**
+ * Get Firebase Storage instance for client-side file operations.
+ */
+export function getFirebaseStorage() {
+  return getStorage(getFirebaseApp());
+}

--- a/next-client/src/lib/firebase/config.ts
+++ b/next-client/src/lib/firebase/config.ts
@@ -1,3 +1,11 @@
+/**
+ * Firebase Configuration
+ *
+ * Shared configuration used by both client and server Firebase SDKs.
+ * Uses environment variables to keep sensitive data secure while
+ * allowing the same config to work in both environments.
+ */
+
 const requiredKeys = [
   "apiKey",
   "authDomain",

--- a/next-client/src/lib/firebase/firestoreClient.ts
+++ b/next-client/src/lib/firebase/firestoreClient.ts
@@ -1,4 +1,15 @@
-import { db } from "./clientApp";
+/**
+ * Firestore Operations (Client SDK)
+ *
+ * Client-side database operations using the Firebase Client SDK.
+ * These operations:
+ * - Run in the browser with user's authentication
+ * - Are subject to Firestore security rules
+ * - Can work offline and sync when reconnected
+ * - Use the user's permissions and auth state
+ */
+
+import { getFirebaseDb } from "./clientApp";
 import { z } from "zod";
 import {
   collection,
@@ -17,11 +28,18 @@ import {
 import { AsyncData, AsyncError } from "../hooks/useAsyncState";
 import { FeedbackRequest } from "../types/clientRoutes";
 
+const db = getFirebaseDb();
+
 const NODE_ENV = z
   .union([z.literal("development"), z.literal("production")])
   .parse(process.env.NODE_ENV);
 const getCollectionName = useGetCollectionName(NODE_ENV);
 
+/**
+ * Get reports for a specific user using client SDK.
+ * This operation goes through Firestore security rules and
+ * uses the client's authentication context.
+ */
 export async function getUsersReports(
   store: typeof db = db,
   userId: string,
@@ -47,6 +65,11 @@ export async function getUsersReports(
   }
 }
 
+/**
+ * Add feedback using client SDK.
+ * This operation is subject to Firestore security rules
+ * and uses the current user's authentication.
+ */
 export async function addFeedback(
   store: typeof db = db,
   data: FeedbackRequest,

--- a/next-client/src/lib/firebase/firestoreServer.ts
+++ b/next-client/src/lib/firebase/firestoreServer.ts
@@ -1,0 +1,33 @@
+/**
+ * Firestore Operations (Server SDK)
+ *
+ * Server-side database operations using the Firebase Admin SDK.
+ * These operations:
+ * - Run on the server with administrative privileges
+ * - Can bypass Firestore security rules when needed
+ * - Are used in API routes and server components
+ * - Have full access to the database regardless of user permissions
+ *
+ * Note: The server SDK bypasses security rules, so we must implement
+ * our own authorization logic in the API routes that use these functions.
+ */
+
+import { Firestore, FieldValue } from "firebase-admin/firestore";
+import { FeedbackRequest } from "../types/clientRoutes";
+
+/**
+ * Add feedback using server SDK with admin privileges.
+ * This bypasses Firestore security rules, so authorization
+ * must be handled in the calling API route.
+ */
+export async function addFeedback(
+  db: Firestore,
+  data: FeedbackRequest,
+): Promise<"success"> {
+  await db.collection("FEEDBACK").add({
+    ...data,
+    userId: data.userId ?? "Unsigned",
+    timestamp: FieldValue.serverTimestamp(),
+  });
+  return "success";
+}

--- a/next-client/src/lib/firebase/getIdToken.ts
+++ b/next-client/src/lib/firebase/getIdToken.ts
@@ -1,0 +1,30 @@
+/**
+ * ID Token Utilities
+ *
+ * Helper functions for working with Firebase ID tokens.
+ * ID tokens are JWTs that prove a user's identity and are used to
+ * authenticate server-side requests.
+ *
+ * Flow:
+ * 1. User signs in via client SDK
+ * 2. Client gets ID token from Firebase Auth
+ * 3. Client sends token in Authorization header to server
+ * 4. Server verifies token using Admin SDK
+ */
+
+import { User } from "firebase/auth";
+
+// Primarily to avoid a security flag for using a hardcoded string in second field.
+// The field is not used as a token without checking for validity first.
+const GENERIC_ERROR_MESSAGE = "An error occurred";
+
+export const fetchToken = async (
+  user: User | null,
+): Promise<["data", string | null] | ["error", string]> => {
+  try {
+    if (!user) return ["data", null];
+    return ["data", await user?.getIdToken()];
+  } catch (e) {
+    return ["error", e instanceof Error ? e.message : GENERIC_ERROR_MESSAGE];
+  }
+};

--- a/next-client/src/lib/firebase/serverApp.ts
+++ b/next-client/src/lib/firebase/serverApp.ts
@@ -1,34 +1,92 @@
+/**
+ * Firebase Server/Admin SDK Setup
+ *
+ * This file initializes the Firebase Admin SDK which runs on the server.
+ * The server SDK is used for:
+ * - Administrative operations with elevated privileges
+ * - Bypassing client security rules when needed
+ * - Server-side user verification and token validation
+ * - Operations that require server-only secrets
+ *
+ * Key differences from client SDK:
+ * - Runs in server environment with admin privileges
+ * - Can bypass Firestore security rules
+ * - Authenticates using service account credentials (not user tokens)
+ * - Cannot run in browser (would expose admin credentials)
+ * - Used for server-side API routes and server components
+ *
+ * IMPORTANT: Runtime Environment Variable Loading
+ * This module uses functions instead of direct initialization because:
+ * 1. Environment variables are loaded at runtime, not compile/build time
+ * 2. Next.js build process may not have access to deployment environment variables
+ * 3. Different environments (dev/staging/prod) need different Firebase configs
+ * 4. Firebase Admin SDK requires credentials to be available before initialization
+ *
+ * This file is designed to work with lazy imports in API routes (see next-client/src/app/api/feedback/route.ts):
+ * - API routes use `await import()` to load this module only when needed
+ * - Ensures environment variables are fully loaded before Firebase initialization
+ * - Prevents build-time errors when credentials aren't available
+ * - Allows proper environment-specific configuration at runtime
+ */
+
 // enforces that this code can only be called on the server
 // https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#keeping-server-only-code-out-of-the-client-environment
 import "server-only";
 
 import { headers } from "next/headers";
-import { initializeServerApp } from "firebase/app";
-
-import { getAuth } from "firebase/auth";
+import { getAuth } from "firebase-admin/auth";
+import { getApps, initializeApp } from "firebase-admin/app";
 import { firebaseConfig } from "./config";
 
-export async function getAuthenticatedAppForUser() {
-  // const idToken = headers().get("Authorization")?.split("Bearer ")[1];
-  const authHeader = (await headers()).get("Authorization");
-  const idToken = authHeader?.split("Bearer ")[1];
-
-  const firebaseServerApp = initializeServerApp(
-    firebaseConfig,
-    idToken
-      ? {
-          authIdToken: idToken,
-        }
-      : {},
-  );
-
-  const auth = getAuth(firebaseServerApp);
-  await auth.authStateReady();
-
-  return { firebaseServerApp, currentUser: auth.currentUser };
+/**
+ * Get or create the Firebase Admin app instance.
+ * Admin SDK has elevated privileges and bypasses client security rules.
+ * Ensures only one app instance exists (singleton pattern).
+ * Multiple instances can supposedly complicate state.
+ */
+function getFirebaseServerApp() {
+  return getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
 }
 
+/**
+ * Authenticate a user request on the server side.
+ *
+ * This function:
+ * 1. Extracts the ID token from the Authorization header
+ * 2. Verifies the token using the Admin SDK
+ * 3. Returns the authenticated user info and admin app instance
+ *
+ * This is necessary because server-side code cannot access browser auth state.
+ * The client must send the ID token in each request header.
+ */
+export async function getAuthenticatedAppForUser() {
+  const authHeader = (await headers()).get("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    throw new Error("Missing or malformed Authorization header");
+  }
+  const idToken = authHeader.split("Bearer ")[1];
+  if (!idToken) {
+    throw new Error("Missing ID token in Authorization header");
+  }
+
+  const auth = getAuth(getFirebaseServerApp());
+
+  // Verify the token came from Firebase Auth and is valid
+  const decodedToken = await auth.verifyIdToken(idToken).catch(() => {
+    throw new Error("Invalid or expired ID token");
+  });
+
+  return {
+    firebaseServerApp: getFirebaseServerApp(),
+    auth,
+    currentUser: decodedToken,
+  };
+}
+
+/**
+ * Get the Firebase Admin app for operations that don't require user authentication.
+ * Used for public operations.
+ */
 export async function getUnauthenticatedApp() {
-  const firebaseServerApp = initializeServerApp(firebaseConfig, {});
-  return { firebaseServerApp };
+  return { firebaseServerApp: getFirebaseServerApp() };
 }

--- a/next-client/src/lib/hooks/getUser.ts
+++ b/next-client/src/lib/hooks/getUser.ts
@@ -2,20 +2,42 @@
 
 import { onAuthStateChanged, User } from "firebase/auth";
 import { useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
 
-import { auth } from "../firebase/clientApp";
+import { getFirebaseAuth } from "../firebase/clientApp";
+const auth = getFirebaseAuth();
+
+// Define protected routes for now
+const protectedRoutes = ["/my-reports", "/create"];
 
 export function useUser() {
   const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (authUser) => {
       setUser(authUser);
+      setLoading(false);
     });
 
     return () => unsubscribe();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Handle redirect for protected routes
+  useEffect(() => {
+    if (!loading && !user) {
+      const isProtectedRoute = protectedRoutes.some((route) =>
+        pathname.startsWith(route),
+      );
+
+      if (isProtectedRoute) {
+        router.push("/");
+      }
+    }
+  }, [user, loading, pathname, router]);
 
   return user;
 }


### PR DESCRIPTION
**1. What is the goal of this PR?**

Continuing the work in https://github.com/AIObjectives/tttc-light-js/pull/179 because I missed some things in my testing. We want to be able to build next-client without requiring the Firebase credentials to be specified at that time, but then able to specify them at runtime to the container. 

This led to a rabbit hole of how Firebase is handled differently between the client and admin SDKs, so that the right credentials are dynamically used at the right time in the right places.

**2. What specific parts of T3C are you changing and how?**

next-client firebase handling, both client and server.

**3. How did you test these changes?**

Local report generation in dev mode with an environment, successful container build without an environment.

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
