### PR TITLE
T3C-97: Use signed URLs to access buckets

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -30,6 +30,10 @@
     "./schema": {
       "types": "./dist/schema/index.d.ts",
       "default": "./dist/schema/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "default": "./dist/utils/index.js"
     }
   },
   "files": [

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -24,7 +24,8 @@
     "./firebase/*",
     "./morphisms/**/*",
     "./prompts/*",
-    "./schema/*"
+    "./schema/*",
+    "./utils/*"
   ],
   "exclude": ["dist/", "**/*/*.test.*"]
 }

--- a/common/utils/index.ts
+++ b/common/utils/index.ts
@@ -1,0 +1,3 @@
+export function assertNever(x: never): never {
+  throw new Error("Unexpected object: " + JSON.stringify(x));
+}

--- a/express-server/src/jobs/pipeline.ts
+++ b/express-server/src/jobs/pipeline.ts
@@ -74,7 +74,7 @@ export async function pipelineJob(job: Job<PipelineJob>) {
   const { auth, env } = config;
   const { title, description, question, filename } = reportDetails;
   // Create our storage object for storing the pipeline's output json
-  const storage = createStorage(env, auth);
+  const storage = createStorage(env);
 
   // Do each of the steps in the pipeline
   // This returns the results of each of the steps.

--- a/express-server/src/routes/sendError.ts
+++ b/express-server/src/routes/sendError.ts
@@ -1,0 +1,18 @@
+import { Response } from "express";
+
+/**
+ * Sends a consistent JSON error response.
+ */
+export function sendError(
+  res: Response,
+  status: number,
+  message: string,
+  errorCode?: string,
+) {
+  res.status(status).json({
+    error: {
+      message,
+      ...(errorCode ? { code: errorCode } : {}),
+    },
+  });
+}

--- a/express-server/src/types/context.ts
+++ b/express-server/src/types/context.ts
@@ -30,9 +30,6 @@ export const env = z.object({
   GCLOUD_STORAGE_BUCKET: z.string({
     required_error: "Missing GCloud storage bucket",
   }),
-  GCLOUD_STORAGE_BUCKET_PRIVATE: z.string({
-    required_error: "Missing GCloud private storage bucket",
-  }),
   GOOGLE_CREDENTIALS_ENCODED: z.string({
     required_error: "Missing encoded GCloud credentials",
   }),
@@ -64,6 +61,7 @@ export const env = z.object({
   //   )
   //   .transform((numstr) => Number(numstr)),
   REDIS_URL: z.string({ required_error: "Missing REDIS_URL" }),
+  ALLOWED_GCS_BUCKETS: z.string().transform((val) => val.split(",")),
 });
 
 export type Env = z.infer<typeof env>;

--- a/next-client/src/app/api/report/download/[uri]/route.ts
+++ b/next-client/src/app/api/report/download/[uri]/route.ts
@@ -24,12 +24,18 @@ const handleParsingJson = (data: unknown): ReportData | Error => {
   }
 };
 
-export async function GET(
-  _: Request,
-  { params }: { params: Promise<{ uri: string }> },
-) {
-  const { uri: encodedUri } = await params;
-  const uri = decodeURIComponent(encodedUri);
+export async function GET(request: Request) {
+  const { pathname } = new URL(request.url);
+  const match = pathname.match(/\/api\/report\/download\/(.+)$/);
+  const uri = match ? match[1] : undefined;
+
+  if (!uri) {
+    return NextResponse.json(
+      { error: "Missing URI parameter" },
+      { status: 400 },
+    );
+  }
+
   const jsonData = await fetch(uri, {
     method: "GET",
     headers: {

--- a/next-client/src/app/report/[uri]/page.tsx
+++ b/next-client/src/app/report/[uri]/page.tsx
@@ -2,17 +2,29 @@ import Report from "@/components/report/Report";
 import { getReportDataObj } from "tttc-common/morphisms/pipeline";
 import * as schema from "tttc-common/schema";
 import * as api from "tttc-common/api";
+import * as utils from "tttc-common/utils";
 import { z } from "zod";
-import ReportProgresss from "@/components/reportProgress/ReportProgress";
+import ReportProgress from "@/components/reportProgress/ReportProgress";
 import Feedback from "@/components/feedback/Feedback";
 
 const waitingMessage = z.object({
   message: z.string(),
 });
 
-type WaitingStatus = ["status", api.ReportJobStatus];
-type ReportData = ["report", schema.UIReportData];
-type Error = ["error"];
+type NotFoundState = { type: "notFound" };
+type ProgressState = { type: "progress"; status: api.ReportJobStatus };
+type ErrorState = { type: "error"; message: string };
+type ReportDataState = {
+  type: "reportData";
+  data: schema.UIReportData;
+  url: string;
+};
+type ReportDataErrorState = { type: "reportDataError"; message: string };
+
+type HandleResponseResult =
+  | { tag: "status"; status: api.ReportJobStatus }
+  | { tag: "report"; data: schema.UIReportData }
+  | { tag: "error"; message: string };
 
 /**
  * When the data resource is fetched, we want to read it and decide how to handle it.
@@ -30,7 +42,7 @@ type Error = ["error"];
 const handleResponseData = async (
   data: unknown,
   url: string,
-): Promise<WaitingStatus | ReportData | Error> => {
+): Promise<HandleResponseResult> => {
   if (waitingMessage.safeParse(data).success) {
     const statusResponse = await fetch(
       z
@@ -44,55 +56,129 @@ const handleResponseData = async (
     const { status } = await statusResponse
       .json()
       .then(api.getReportResponse.parse);
-    return ["status", status as api.ReportJobStatus];
+    return { tag: "status", status: status as api.ReportJobStatus };
   } else if (schema.llmPipelineOutput.safeParse(data).success) {
     // if the data is from the old schema, then translate it into the new one
     const newSchemaData = getReportDataObj(
       schema.llmPipelineOutput.parse(data),
     );
-    return ["report", schema.uiReportData.parse(newSchemaData)];
+    return { tag: "report", data: schema.uiReportData.parse(newSchemaData) };
   } else if (schema.pipelineOutput.safeParse(data).success) {
-    return [
-      "report",
-      schema.uiReportData.parse(schema.pipelineOutput.parse(data).data[1]),
-    ];
+    return {
+      tag: "report",
+      data: schema.uiReportData.parse(
+        schema.pipelineOutput.parse(data).data[1],
+      ),
+    };
   } else if (schema.downloadReportSchema.safeParse(data).success) {
-    return ["report", schema.downloadReportSchema.parse(data)[1].data[1]];
+    return {
+      tag: "report",
+      data: schema.downloadReportSchema.parse(data)[1].data[1],
+    };
   } else {
-    return ["error"];
+    return { tag: "error", message: "Unknown error" };
   }
 };
 
-type PageProps = Promise<{
-  uri: string;
-}>;
-
-export default async function ReportPage({ params }: { params: PageProps }) {
-  const uri = (await params).uri.replace(/\?.*$/, "");
-  const url = decodeURIComponent(uri);
-  const req = await fetch(url, {
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-  let data = await req.json();
-
-  const parsedData = await handleResponseData(data, url);
-
-  switch (parsedData[0]) {
-    case "status": {
-      return <ReportProgresss status={parsedData[1]} />;
+async function getReportState(
+  encodedUri: string,
+): Promise<
+  | NotFoundState
+  | ProgressState
+  | ErrorState
+  | ReportDataState
+  | ReportDataErrorState
+> {
+  const baseApiUrl = process.env.PIPELINE_EXPRESS_URL ?? "";
+  const statusUrl = `${baseApiUrl}/report/${encodedUri}/status`;
+  try {
+    const statusRes = await fetch(statusUrl);
+    if (statusRes.status === 404) {
+      return { type: "notFound" };
     }
-    case "report": {
+    if (!statusRes.ok) {
+      return { type: "error", message: "Failed to fetch report status." };
+    }
+    const statusJson = await statusRes.json();
+    const status = statusJson.status as api.ReportJobStatus;
+
+    if (status === "failed") {
+      return { type: "progress", status };
+    }
+    if (status && status !== "finished" && status !== "notFound") {
+      return { type: "progress", status };
+    }
+
+    // Try to fetch signed URL for report data
+    const dataUrl = `${baseApiUrl}/report/${encodedUri}/data`;
+    const dataRes = await fetch(dataUrl);
+    if (dataRes.status === 404) {
+      return { type: "notFound" };
+    }
+    if (!dataRes.ok) {
+      return {
+        type: "error",
+        message:
+          "Failed to fetch report data. The file may not be public, may not exist, or you may not have access.",
+      };
+    }
+    const url = (await dataRes.json()).url as string | undefined;
+    const finalUrl = url || decodeURIComponent(encodedUri);
+
+    // Fetch the actual report data
+    try {
+      const reportRes = await fetch(finalUrl);
+      const reportData = await reportRes.json();
+      const parsedData = await handleResponseData(reportData, finalUrl);
+
+      switch (parsedData.tag) {
+        case "status":
+          return { type: "progress", status: parsedData.status };
+        case "report":
+          return { type: "reportData", data: parsedData.data, url: finalUrl };
+        case "error":
+          return { type: "reportDataError", message: parsedData.message };
+        default:
+          utils.assertNever(parsedData);
+      }
+    } catch (e) {
+      return {
+        type: "reportDataError",
+        message:
+          "Failed to fetch report data. The file may not be public or may not exist.",
+      };
+    }
+  } catch (e) {
+    return { type: "error", message: "Unexpected error loading report." };
+  }
+}
+
+export default async function ReportPage({
+  params,
+}: {
+  params: Promise<{ uri: string }>;
+}) {
+  const { uri } = await params;
+  const encodedUri = encodeURIComponent(decodeURIComponent(uri));
+  const state = await getReportState(encodedUri);
+
+  switch (state.type) {
+    case "notFound":
+      return <ReportProgress status="notFound" />;
+    case "progress":
+      return <ReportProgress status={state.status} />;
+    case "error":
+      return <p>{state.message}</p>;
+    case "reportData":
       return (
         <div>
-          <Report reportData={parsedData[1]} reportUri={url} />
+          <Report reportData={state.data} reportUri={state.url} />
           <Feedback className="hidden lg:block" />
         </div>
       );
-    }
-    case "error": {
-      return <p>An error occured</p>;
-    }
+    case "reportDataError":
+      return <p>{state.message}</p>;
+    default:
+      utils.assertNever(state);
   }
 }

--- a/next-client/src/components/reportProgress/ReportProgress.tsx
+++ b/next-client/src/components/reportProgress/ReportProgress.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import * as api from "tttc-common/api";
+import * as utils from "tttc-common/utils";
 import { Col } from "../layout";
 import { Progress } from "../elements";
 
-export default function ReportProgresss({
+export default function ReportProgress({
   status,
 }: {
   status: api.ReportJobStatus;
@@ -28,16 +29,18 @@ const Body = ({ status }: { status: api.ReportJobStatus }) => {
   }
 };
 
-const JobFailed = () => <p>Your report failed</p>;
+const JobFailed = (_: unknown) => <p>Your report failed</p>;
 
-const JobFinished = () => (
+const JobFinished = (_: unknown) => (
   <p>
     Report finished but data not found - likely that resource was moved or
     deleted
   </p>
 );
 
-const JobNotFound = () => <p>Could not find a valid report with that uri</p>;
+const JobNotFound = (_: unknown) => (
+  <p>Could not find a valid report with that uri</p>
+);
 
 function ReportProcessing({ status }: { status: api.ReportJobStatus }) {
   return (
@@ -70,14 +73,7 @@ const statusToProgress = (status: api.ReportJobStatus) => {
     case "notFound":
       return -100;
     default: {
-      if (process.env.NODE_ENV === "development") {
-        throw new Error(`Unrecognized value in statusToProgress: ${status}`);
-      } else {
-        console.warn(
-          "GOT AN UNEXPECTED VALUE IN REPORT PROGRESS statusToProgress",
-        );
-        return 90; // idk what to have, but at least it won't crash now. Fixme
-      }
+      utils.assertNever(status);
     }
   }
 };
@@ -103,6 +99,6 @@ const statusMessage = (status: api.ReportJobStatus) => {
     case "notFound":
       return "Not found :/";
     default:
-      throw new Error("Unrecognized value in statusMessage");
+      utils.assertNever(status);
   }
 };


### PR DESCRIPTION
This enables buckets to be made default-private.

**1. What is the goal of this PR?**

Use signed URLs generated with appropriate credentials that allow buckets to be default-private. 
Still allow accessing old reports in public buckets.
Restrict access to only our public buckets.

**2. What specific parts of T3C are you changing and how?**

express-server and next-client handling of report status and report data fetching, both the actual generation of signed URLs and making the interaction more RESTful.

**3. How did you test these changes?**

Report browsing and creation, locally.

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
