### PR TITLE
T3C-313: Fix missing .env file in Cloud Build via a build arg

### DIFF
--- a/.github/workflows/deploy-next-client.yml
+++ b/.github/workflows/deploy-next-client.yml
@@ -24,18 +24,13 @@ jobs:
         with:
           project_id: tttc-light-js
 
-      ####
-      - name: Write .env file for Next Client
-        run: |
-          echo "${{ secrets.ENV_CLIENT }}" > next-client/.env
-
-      ####
       - name: Build and Push Docker Image
         run: |
           gcloud builds submit . \
             --project=tttc-light-js \
             --timeout=1200s \
-            --config=next-client/cloudbuild.yaml
+            --config=next-client/cloudbuild.yaml \
+            --substitutions=_ENV_FILE_CONTENT="${{ secrets.ENV_CLIENT }}"
 
       - name: Deploy to Cloud Run
         run: |

--- a/next-client/Dockerfile
+++ b/next-client/Dockerfile
@@ -30,8 +30,16 @@ COPY next-client/ ./next-client/
 
 # Build common first
 RUN npm run build --prefix ./common
-# Then build next-client with standalone output
-RUN npm run build --prefix ./next-client
+
+# Accept build arg and write .env file
+ARG ENV_FILE_CONTENT
+RUN cat <<EOF > ./next-client/.env
+$ENV_FILE_CONTENT
+EOF
+
+# Build next-client
+RUN npm run build --prefix ./next-client \
+    && rm -f ./next-client/.env
 
 # Production image
 FROM base AS runner

--- a/next-client/cloudbuild.yaml
+++ b/next-client/cloudbuild.yaml
@@ -7,6 +7,8 @@ steps:
         "gcr.io/tttc-light-js/t3c-next-client-staging",
         "-f",
         "next-client/Dockerfile",
+        "--build-arg",
+        "ENV_FILE_CONTENT=${_ENV_FILE_CONTENT}",
         ".",
       ]
 images:


### PR DESCRIPTION
**1. What is the goal of this PR?**

Cloud builds produce non-working artifacts because the .env file gets ignored during the upload. It seems like the cleanest way to provide it is therefore a docker build arg. This does change the syntax for local building too, but the compromise seems ok for now.

**2. What specific parts of T3C are you changing and how?**

next-client cloud build process.

**3. How did you test these changes?**

Staging deploy with locally built artifact, which isn't the same but it's hard to test cloud build as currently configured.

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
