### PR TITLE
Revert "T3C-313: Fix missing .env file in Cloud Build via a build arg"

### DIFF
--- a/.github/workflows/deploy-next-client.yml
+++ b/.github/workflows/deploy-next-client.yml
@@ -24,13 +24,18 @@ jobs:
         with:
           project_id: tttc-light-js
 
+      ####
+      - name: Write .env file for Next Client
+        run: |
+          echo "${{ secrets.ENV_CLIENT }}" > next-client/.env
+
+      ####
       - name: Build and Push Docker Image
         run: |
           gcloud builds submit . \
             --project=tttc-light-js \
             --timeout=1200s \
-            --config=next-client/cloudbuild.yaml \
-            --substitutions=_ENV_FILE_CONTENT="${{ secrets.ENV_CLIENT }}"
+            --config=next-client/cloudbuild.yaml
 
       - name: Deploy to Cloud Run
         run: |

--- a/next-client/Dockerfile
+++ b/next-client/Dockerfile
@@ -30,16 +30,8 @@ COPY next-client/ ./next-client/
 
 # Build common first
 RUN npm run build --prefix ./common
-
-# Accept build arg and write .env file
-ARG ENV_FILE_CONTENT
-RUN cat <<EOF > ./next-client/.env
-$ENV_FILE_CONTENT
-EOF
-
-# Build next-client
-RUN npm run build --prefix ./next-client \
-    && rm -f ./next-client/.env
+# Then build next-client with standalone output
+RUN npm run build --prefix ./next-client
 
 # Production image
 FROM base AS runner

--- a/next-client/cloudbuild.yaml
+++ b/next-client/cloudbuild.yaml
@@ -7,8 +7,6 @@ steps:
         "gcr.io/tttc-light-js/t3c-next-client-staging",
         "-f",
         "next-client/Dockerfile",
-        "--build-arg",
-        "ENV_FILE_CONTENT=${_ENV_FILE_CONTENT}",
         ".",
       ]
 images:


### PR DESCRIPTION
Reverts AIObjectives/tttc-light-js#188

Cloud Build doesn't support docker heredocs, so this approach needs to be revisited.