### PR TITLE
T3C-373 moved the result type from express server to common and updated imports

### DIFF
--- a/common/functional-utils/__tests__/result.test.ts
+++ b/common/functional-utils/__tests__/result.test.ts
@@ -7,7 +7,7 @@ import {
   flatMapResult,
   flatMapResultAsync,
   sequenceResult,
-} from "../";
+} from "../result";
 
 const s = success(1) as Result<number, boolean>;
 const f = failure(false) as Result<number, boolean>;

--- a/common/functional-utils/index.ts
+++ b/common/functional-utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./result";

--- a/common/functional-utils/result.ts
+++ b/common/functional-utils/result.ts
@@ -1,7 +1,7 @@
 /**
  * Represents a successful result
  */
-type Success<T> = {
+export type Success<T> = {
   tag: "success";
   value: T;
 };
@@ -9,7 +9,7 @@ type Success<T> = {
 /**
  * Represents some expected failure so we can explicitly handle them.
  */
-type Failure<T> = {
+export type Failure<T> = {
   tag: "failure";
   error: T;
 };

--- a/common/package.json
+++ b/common/package.json
@@ -15,6 +15,10 @@
       "types": "./dist/firebase/index.d.ts",
       "default": "./dist/firebase/index.js"
     },
+    "./functional-utils": {
+      "types": "./dist/functional-utils/index.d.ts",
+      "default": "./dist/functional-utils/index.js"
+    },
     "./morphisms": {
       "types": "./dist/morphisms/index.d.ts",
       "default": "./dist/morphisms/index.js"

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -22,6 +22,7 @@
     "./api/*",
     "./apiPyserver/*",
     "./firebase/*",
+    "./functional-utils/*",
     "./morphisms/**/*",
     "./prompts/*",
     "./schema/*",

--- a/express-server/src/jobs/pipeline.ts
+++ b/express-server/src/jobs/pipeline.ts
@@ -10,7 +10,7 @@ import {
   mapResult,
   sequenceResult,
   success,
-} from "../types/result";
+} from "tttc-common/functional-utils";
 import { CustomError } from "../error";
 import * as Pyserver from "../pipeline/";
 import { randomUUID } from "crypto";

--- a/express-server/src/pipeline/claimsStep.ts
+++ b/express-server/src/pipeline/claimsStep.ts
@@ -4,7 +4,7 @@ import { Env } from "../types/context";
 import { Client, Dispatcher } from "undici";
 import { AbortController } from "abort-controller"; // If needed in your environment
 import { TimeoutError, FetchError, InvalidResponseDataError } from "./errors";
-import { flatMapResult, Result } from "../types/result";
+import { flatMapResult, Result } from "tttc-common/functional-utils";
 
 /**
  * Sends an http request to the pyserver for the claims step

--- a/express-server/src/pipeline/handlePipelineStep.ts
+++ b/express-server/src/pipeline/handlePipelineStep.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { flatMapResult, Result } from "../types/result";
+import { flatMapResult, Result } from "tttc-common/functional-utils";
 import { FetchError, InvalidResponseDataError } from "./errors";
 
 /**

--- a/express-server/src/routes/create.ts
+++ b/express-server/src/routes/create.ts
@@ -10,7 +10,7 @@ import * as firebase from "../Firebase";
 import { DecodedIdToken } from "firebase-admin/auth";
 import { PipelineJob } from "src/jobs/pipeline";
 import { sendError } from "./sendError";
-import { Result } from "../types/result";
+import { Result } from "tttc-common/functional-utils";
 
 class CreateReportError extends Error {
   constructor(message: string) {

--- a/express-server/src/routes/report.ts
+++ b/express-server/src/routes/report.ts
@@ -4,7 +4,7 @@ import * as utils from "tttc-common/utils";
 import { pipelineQueue } from "../server";
 import { Bucket, createStorage } from "../storage";
 import { sendError } from "./sendError";
-import { Result } from "../types/result";
+import { Result } from "tttc-common/functional-utils";
 class BucketParseError extends Error {
   constructor(message: string) {
     super(message);

--- a/express-server/src/storage.ts
+++ b/express-server/src/storage.ts
@@ -6,7 +6,7 @@ import {
 import { CustomError } from "./error";
 import * as schema from "tttc-common/schema";
 import { z } from "zod";
-import { Result } from "./types/result";
+import { Result } from "tttc-common/functional-utils";
 import { Env } from "./types/context";
 
 const fileContent = z.union([schema.pipelineOutput, schema.uiReportData]);


### PR DESCRIPTION


Takes the Result type in the express server and lifts it to common so that we can use it across the frontend and backend


Linear is currently experiencing a problem, so this is in draft mode until then