### PR TITLE
T3C-419 fixed crash when clicking on point graphic cell

### DIFF
--- a/next-client/src/components/outline/hooks/__tests__/useOutlineState.close.test.ts
+++ b/next-client/src/components/outline/hooks/__tests__/useOutlineState.close.test.ts
@@ -8,7 +8,7 @@ const { createReducer, mapIdsToPath, createInitialState } = __internals;
 
 const reportState = reportStateBuilder(reportData.topics);
 const outlineState = createInitialState(reportState);
-const idMap = mapIdsToPath(outlineState);
+const idMap = mapIdsToPath(reportState);
 const reducer = createReducer(idMap);
 
 const open = (state: OutlineState, id: string) =>

--- a/next-client/src/components/outline/hooks/__tests__/useOutlineState.closeAll.test.ts
+++ b/next-client/src/components/outline/hooks/__tests__/useOutlineState.closeAll.test.ts
@@ -8,7 +8,7 @@ const { createReducer, mapIdsToPath, createInitialState } = __internals;
 
 const reportState = reportStateBuilder(reportData.topics);
 const outlineState = createInitialState(reportState);
-const idMap = mapIdsToPath(outlineState);
+const idMap = mapIdsToPath(reportState);
 const reducer = createReducer(idMap);
 
 const openAll = (state: OutlineState) => reducer(state, { type: "openAll" });

--- a/next-client/src/components/outline/hooks/__tests__/useOutlineState.highlight.test.ts
+++ b/next-client/src/components/outline/hooks/__tests__/useOutlineState.highlight.test.ts
@@ -8,7 +8,7 @@ const { createReducer, mapIdsToPath, createInitialState } = __internals;
 
 const reportState = reportStateBuilder(reportData.topics);
 const outlineState = createInitialState(reportState);
-const idMap = mapIdsToPath(outlineState);
+const idMap = mapIdsToPath(reportState);
 const reducer = createReducer(idMap);
 
 const highlight = (state: OutlineState, id: string) =>

--- a/next-client/src/components/outline/hooks/__tests__/useOutlineState.open.test.ts
+++ b/next-client/src/components/outline/hooks/__tests__/useOutlineState.open.test.ts
@@ -8,7 +8,7 @@ const { createReducer, mapIdsToPath, createInitialState } = __internals;
 
 const reportState = reportStateBuilder(reportData.topics);
 const outlineState = createInitialState(reportState);
-const idMap = mapIdsToPath(outlineState);
+const idMap = mapIdsToPath(reportState);
 const reducer = createReducer(idMap);
 
 const open = (state: OutlineState, id: string) =>
@@ -35,5 +35,23 @@ describe("Opening topic nodes", () => {
 
     const vals = secondState.tree.map((node) => node.isOpen);
     expect(vals).toEqual(Array.makeBy(vals.length, () => true));
+  });
+});
+
+describe("Opening claim nodes", () => {
+  test("should open parent topic when opening a claim ID", () => {
+    const firstClaim = reportState.children[0].children[0].children[0];
+    const claimId = firstClaim.id;
+
+    const newState = open(outlineState, claimId);
+
+    expect(newState.tree[0].isOpen).toBe(true);
+  });
+
+  test("should not throw error when opening claim ID", () => {
+    const firstClaim = reportState.children[0].children[0].children[0];
+    const claimId = firstClaim.id;
+
+    expect(() => open(outlineState, claimId)).not.toThrow();
   });
 });

--- a/next-client/src/components/outline/hooks/__tests__/useOutlineState.openAll.test.ts
+++ b/next-client/src/components/outline/hooks/__tests__/useOutlineState.openAll.test.ts
@@ -8,7 +8,7 @@ const { createReducer, mapIdsToPath, createInitialState } = __internals;
 
 const reportState = reportStateBuilder(reportData.topics);
 const outlineState = createInitialState(reportState);
-const idMap = mapIdsToPath(outlineState);
+const idMap = mapIdsToPath(reportState);
 const reducer = createReducer(idMap);
 
 const openAll = (state: OutlineState) => reducer(state, { type: "openAll" });

--- a/next-client/src/components/outline/hooks/__tests__/useOutlineState.toggle.test.ts
+++ b/next-client/src/components/outline/hooks/__tests__/useOutlineState.toggle.test.ts
@@ -7,7 +7,7 @@ const { createReducer, mapIdsToPath, createInitialState } = __internals;
 
 const reportState = reportStateBuilder(reportData.topics);
 const outlineState = createInitialState(reportState);
-const idMap = mapIdsToPath(outlineState);
+const idMap = mapIdsToPath(reportState);
 const reducer = createReducer(idMap);
 
 const toggle = (state: OutlineState, id: string) =>

--- a/next-client/src/components/outline/hooks/useOutlineState/hook.ts
+++ b/next-client/src/components/outline/hooks/useOutlineState/hook.ts
@@ -9,7 +9,7 @@ export function useOutlineState(
   reportState: ReportState,
 ): [OutlineState, Dispatch<OutlineStateAction>] {
   const initialState: OutlineState = createInitialState(reportState);
-  const idMap = mapIdsToPath(initialState);
+  const idMap = mapIdsToPath(reportState);
   const reducer = createReducer(idMap);
   const [state, dispatch] = useReducer(reducer, initialState);
   return [state, dispatch];

--- a/next-client/src/components/outline/hooks/useOutlineState/path.ts
+++ b/next-client/src/components/outline/hooks/useOutlineState/path.ts
@@ -1,17 +1,26 @@
 import { pipe, Array, Record } from "effect";
 import { OutlineState, TaggedSubtopicPath, TaggedTopicPath } from "./types";
+import { ReportState } from "@/components/report/hooks/useReportState";
 
 /**
  * Maps outline ids to their location in the outline state
  */
 export const mapIdsToPath = (
-  state: OutlineState,
+  reportState: ReportState,
 ): Record<string, TaggedTopicPath | TaggedSubtopicPath> => {
   const idMap: Record<string, TaggedTopicPath | TaggedSubtopicPath> = {};
-  state.tree.forEach((topic, i) => {
+  reportState.children.forEach((topic, i) => {
     idMap[topic.id] = { type: "topic", topicIdx: i };
     topic.children.forEach((subtopic, j) => {
-      idMap[subtopic.id] = { type: "subtopic", topicIdx: i, subtopicIdx: j };
+      const subtopicPath = {
+        type: "subtopic",
+        topicIdx: i,
+        subtopicIdx: j,
+      } as TaggedSubtopicPath;
+      idMap[subtopic.id] = subtopicPath;
+      subtopic.children.forEach((claim) => {
+        idMap[claim.id] = subtopicPath;
+      });
     });
   });
   return idMap;


### PR DESCRIPTION
Fixes the crash by changing outline state's idmap to use report state and to have claim ids point to their parent subtopic in the outline.
