### PR TITLE
T3C-421 Updates port mapping for production python server

### DIFF
--- a/pyserver/Dockerfile
+++ b/pyserver/Dockerfile
@@ -7,9 +7,9 @@ RUN pip install --no-cache-dir --upgrade -r requirements.txt
 RUN useradd --no-create-home appuser
 COPY --chown=appuser pyserver/ .
 
-ENV PORT=8080
-EXPOSE 8080
+ENV PORT=8000
+EXPOSE $PORT
 
 USER appuser
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD uvicorn main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
**1. What is the goal of this PR?**
Locally the python server is running at 8000 but in production is running on port 8080.  This will ensure that local and production environments are running on the same ports.
**2. What specific parts of T3C are you changing and how?**
This changes the port that is being listened on for the Python service.  There should be noticeable effect.  
**3. How did you test these changes?**
Ran local docker-compose to ensure that pyserv was listening on port 8000

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
