### PR TITLE
T3C-158: Upgrade from node 18 to node 24

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,12 +34,12 @@ This guide covers setting up a local development environment for Talk to the Cit
 
 Before starting setup, ensure you have:
 
-- **Node.js 18+** and npm
+- **Node.js 24+** and npm
   - **New to Node.js?** Use [nvm](https://github.com/nvm-sh/nvm) to easily install and switch between Node.js versions:
     ```bash
-    # Install and use Node.js 18
-    nvm install 18
-    nvm use 18
+    # Install and use Node.js 24
+    nvm install 24
+    nvm use 24
     ```
 - **Python 3.8+** and pip
 - **Redis server** (local or remote)

--- a/common/package.json
+++ b/common/package.json
@@ -48,6 +48,9 @@
       "default": "./dist/csv-security/index.js"
     }
   },
+  "engines": {
+    "node": ">=24"
+  },
   "files": [
     "dist"
   ],

--- a/express-server/Dockerfile
+++ b/express-server/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Install dependencies and build
-FROM node:18-slim AS build
+FROM node:24-slim AS build
 
 WORKDIR /usr/src/app
 
@@ -15,7 +15,7 @@ RUN npm run build --prefix ./common
 RUN npm run build --prefix ./express-server
 
 # Stage 2: Production image
-FROM node:18-slim
+FROM node:24-slim
 
 WORKDIR /usr/src/app
 

--- a/express-server/package.json
+++ b/express-server/package.json
@@ -2,6 +2,9 @@
   "name": "express-pipeline",
   "version": "1.0.0",
   "description": "pipeline for tttc-light-js",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "npx babel src --out-dir dist --extensions \".tsx,.ts\" && npx prettier ./dist --write",
     "dev": "nodemon src/server.ts",

--- a/next-client/Dockerfile
+++ b/next-client/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1
-FROM node:18-alpine AS base
+FROM node:24-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/next-client/package.json
+++ b/next-client/package.json
@@ -2,6 +2,9 @@
   "name": "next-client",
   "version": "1.0.0",
   "description": "client for talk-to-the-city light js",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "next build",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "author": "Bruno Marnette",
   "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
   "devDependencies": {
     "husky": "^9.0.11",
     "prettier": "3.2.5",


### PR DESCRIPTION
**1. What is the goal of this PR?**

Upgrade default node version from 18 to 24, since 18 is EOL.

**2. What specific parts of T3C are you changing and how?**

common, next-client, express-server node versions

**3. How did you test these changes?**

Local report generation.

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
