### PR TITLE
T3C-470 Update node command to receive stop command from GCP

### DIFF
--- a/express-server/Dockerfile
+++ b/express-server/Dockerfile
@@ -34,4 +34,4 @@ HEALTHCHECK CMD curl --fail http://localhost:8080/ || exit 1
 RUN useradd --user-group --create-home --shell /bin/false appuser
 USER appuser
 
-CMD ["npm", "start"]
+CMD ["node", "dist/server.js"]


### PR DESCRIPTION
**1. What is the goal of this PR?**
Make the node process the main process for GCP to send the stop signal to, allowing for graceful shutdown
**2. What specific parts of T3C are you changing and how?**
express-server 
Updating Dockerfile to use node instead of npm to start the server
**3. How did you test these changes?**
Ran a local docker image to make sure the server started up

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
