### PR TITLE
T3C-491: Remove unnecessary .env files from deploy workflows

### DIFF
--- a/.github/workflows/deploy-express-server-production.yml
+++ b/.github/workflows/deploy-express-server-production.yml
@@ -36,10 +36,6 @@ jobs:
 
       ####
 
-      - name: Write .env file for Express
-        run: |
-          echo "${{ secrets.ENV_EXPRESS_SERVER }}" > express-server/.env
-
       - name: Build Docker image
         run: |
           docker build -t gcr.io/tttc-light-js/t3c-express-server -f express-server/Dockerfile .
@@ -56,6 +52,3 @@ jobs:
             --platform managed \
             --region us-central1 \
             --allow-unauthenticated
-
-      - name: Remove .env file
-        run: rm -f express-server/.env

--- a/.github/workflows/deploy-express-server.yml
+++ b/.github/workflows/deploy-express-server.yml
@@ -38,10 +38,6 @@ jobs:
 
       ####
 
-      - name: Write .env file for Express
-        run: |
-          echo "${{ secrets.ENV_EXPRESS_SERVER }}" > express-server/.env
-
       - name: Build Docker image
         run: |
           docker build -t gcr.io/tttc-light-js/stage-t3c-express-server -f express-server/Dockerfile .
@@ -58,6 +54,3 @@ jobs:
             --platform managed \
             --region us-central1 \
             --allow-unauthenticated
-
-      - name: Remove .env file
-        run: rm -f express-server/.env

--- a/.github/workflows/deploy-pyserver-production.yml
+++ b/.github/workflows/deploy-pyserver-production.yml
@@ -35,10 +35,6 @@ jobs:
         with:
           project_id: tttc-light-js
       ####
-      - name: Write .env file for Pyserver
-        run: |
-          echo "${{ secrets.ENV_PYSERVER }}" > pyserver/.env
-
       - name: Build Docker image
         run: |
           docker build -t gcr.io/tttc-light-js/pyserver-brandon -f pyserver/Dockerfile .
@@ -55,6 +51,3 @@ jobs:
             --platform managed \
             --region us-central1 \
             --allow-unauthenticated
-
-      - name: Remove .env file
-        run: rm -f pyserver/.env

--- a/.github/workflows/deploy-pyserver.yml
+++ b/.github/workflows/deploy-pyserver.yml
@@ -37,10 +37,6 @@ jobs:
         with:
           project_id: tttc-light-js
       ####
-      - name: Write .env file for Pyserver
-        run: |
-          echo "${{ secrets.ENV_PYSERVER }}" > pyserver/.env
-
       - name: Build Docker image
         run: |
           docker build -t gcr.io/tttc-light-js/stage-t3c-pyserver -f pyserver/Dockerfile .
@@ -57,6 +53,3 @@ jobs:
             --platform managed \
             --region us-central1 \
             --allow-unauthenticated
-
-      - name: Remove .env file
-        run: rm -f pyserver/.env


### PR DESCRIPTION
**1. What is the goal of this PR?**

Remove unnecessary .env files and logic from build and deploy scripts. Only next-client requires a buildtime .env, the rest are runtime via CloudRun.

**2. What specific parts of T3C are you changing and how?**

Build and deploy workflows for express-server and pyserver.

**3. How did you test these changes?**

Hard to test without actually redeploying staging, so untested.

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
