### PR TITLE
T3C-544: Move new Firestore query to express-server

### DIFF
--- a/express-server/src/routes/create.ts
+++ b/express-server/src/routes/create.ts
@@ -201,6 +201,7 @@ const handleUserAuthenticationAndCreateDocuments = async (
         numPeople: 0, // Placeholder, will be updated
         createdDate: new Date(),
       },
+      preGeneratedReportId, // Use the same reportId as storage filename
     );
 
     createLogger.info(

--- a/express-server/src/routes/report.ts
+++ b/express-server/src/routes/report.ts
@@ -367,3 +367,34 @@ export async function getReportByIdDataHandler(
     );
   }
 }
+
+export async function getReportByIdMetadataHandler(
+  req: RequestWithLogger & { auth?: DecodedIdToken },
+  res: Response,
+) {
+  const reportId = req.params.reportId;
+
+  // Basic validation
+  if (!isValidFirebaseId(reportId)) {
+    return sendError(res, 404, "Report not found", "ReportNotFound");
+  }
+
+  try {
+    const reportRef = await getReportRefById(reportId);
+    if (!reportRef) {
+      return sendError(res, 404, "Report not found", "ReportNotFound");
+    }
+
+    // Add cache headers for metadata
+    res.set("Cache-Control", "private, max-age=300"); // 5 minutes
+    res.json(reportRef);
+  } catch (error) {
+    reportLogger.error({ error, reportId }, "Error getting report metadata");
+    return sendError(
+      res,
+      500,
+      "Failed to fetch report metadata",
+      "MetadataError",
+    );
+  }
+}

--- a/express-server/src/server.ts
+++ b/express-server/src/server.ts
@@ -19,6 +19,7 @@ import {
   getReportDataHandler,
   getReportByIdDataHandler,
   getReportByIdStatusHandler,
+  getReportByIdMetadataHandler,
   migrateReportUrlHandler,
 } from "./routes/report";
 import { setupConnection } from "./Queue";
@@ -173,6 +174,11 @@ app.get(
   "/report/id/:reportId/status",
   reportLimiter,
   getReportByIdStatusHandler,
+);
+app.get(
+  "/report/id/:reportId/metadata",
+  reportLimiter,
+  getReportByIdMetadataHandler,
 );
 
 /**

--- a/next-client/src/app/api/report/id/[id]/metadata/route.ts
+++ b/next-client/src/app/api/report/id/[id]/metadata/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { logger } from "tttc-common/logger/browser";
+import { FIRESTORE_ID_REGEX } from "tttc-common/utils";
+
+const reportMetadataLogger = logger.child({ module: "report-metadata" });
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+
+    // Validate report ID format
+    if (!id || !FIRESTORE_ID_REGEX.test(id)) {
+      return NextResponse.json(
+        { error: "Invalid report ID format" },
+        { status: 400 },
+      );
+    }
+
+    reportMetadataLogger.debug(
+      { reportId: id },
+      "Fetching metadata for report",
+    );
+
+    // Call the express server's report ID metadata endpoint
+    const expressUrl =
+      process.env.PIPELINE_EXPRESS_URL || "http://localhost:8080";
+
+    const expressResponse = await fetch(
+      `${expressUrl}/report/id/${id}/metadata`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    reportMetadataLogger.debug(
+      { status: expressResponse.status },
+      "Express server response received",
+    );
+
+    if (!expressResponse.ok) {
+      const errorData = await expressResponse.text().catch(() => null);
+      return NextResponse.json(
+        { error: errorData || "Failed to fetch report metadata" },
+        { status: expressResponse.status },
+      );
+    }
+
+    const metadata = await expressResponse.json();
+    reportMetadataLogger.debug("Report metadata fetched successfully");
+
+    return NextResponse.json(metadata);
+  } catch (error) {
+    reportMetadataLogger.error({ error }, "Error in report metadata API");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
**1. What is the goal of this PR?**

Fix frontend Firestore query permissions issue
Fix Firestore document id bug

**2. What specific parts of T3C are you changing and how?**

Changed some express-server Firestore logic, moved some next-client logic to express-server.

**3. How did you test these changes?**

Local tests and report generation.

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
