### PR TITLE
T3C-544: Distinguish rate limiting from other errors

### DIFF
--- a/express-server/src/server.ts
+++ b/express-server/src/server.ts
@@ -120,7 +120,7 @@ const defaultRateLimiter = rateLimit({
 // Stricter rate limiter for report endpoints
 const reportRateLimiter = rateLimit({
   windowMs: 5 * 60 * 1000, // 5 minutes
-  max: 30, // Limit each IP to 30 report requests per windowMs
+  max: 60, // Limit each IP to 60 report requests per windowMs (1 per 5 seconds)
   message: {
     error: {
       message: "Too many requests, please try again later.",
@@ -177,7 +177,7 @@ app.get(
 );
 app.get(
   "/report/id/:reportId/metadata",
-  reportLimiter,
+  rateLimiter, // Use default rate limiter (100 req/15 min) for read-only metadata
   getReportByIdMetadataHandler,
 );
 


### PR DESCRIPTION
Slightly relax rate limiter due to report creation burst

**1. What is the goal of this PR?**

Fix misleading error message about missing report when rate limited.
Adjust for spike of requests at report creation time causing rate limiting.

**2. What specific parts of T3C are you changing and how?**

express-server rate limiters, next-client status parsing.

**3. How did you test these changes?**

Locally.

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
