### PR TITLE
T3C-327: Allow flexible column names to support CSV extractor

### DIFF
--- a/express-server/src/__tests__/utils.test.ts
+++ b/express-server/src/__tests__/utils.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from "vitest";
+import { formatData } from "tttc-common/utils";
+
+describe("formatData", () => {
+  describe("WhatsApp consultation format", () => {
+    it("should map WhatsApp columns to standard format", () => {
+      const whatsappData = [
+        {
+          "comment-id": "1",
+          "comment-body": "This is a test comment",
+          name: "Speaker A",
+        },
+        {
+          "comment-id": "2",
+          "comment-body": "Another comment",
+          name: "Speaker B",
+        },
+      ];
+
+      const result = formatData(whatsappData);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        id: "1",
+        comment: "This is a test comment",
+        interview: "Speaker A",
+      });
+      expect(result[1]).toEqual({
+        id: "2",
+        comment: "Another comment",
+        interview: "Speaker B",
+      });
+    });
+  });
+
+  describe("Standard T3C format", () => {
+    it("should handle standard column names", () => {
+      const standardData = [
+        {
+          id: "1",
+          comment: "Standard comment",
+          interview: "Speaker A",
+        },
+        {
+          id: "2",
+          comment: "Another standard comment",
+          interview: "Speaker B",
+        },
+      ];
+
+      const result = formatData(standardData);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        id: "1",
+        comment: "Standard comment",
+        interview: "Speaker A",
+      });
+    });
+  });
+
+  describe("Alternative column names", () => {
+    it("should map 'response' to comment", () => {
+      const data = [
+        {
+          id: "1",
+          response: "A response text",
+          interview: "Speaker A",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].comment).toBe("A response text");
+    });
+
+    it("should map 'answer' to comment", () => {
+      const data = [
+        {
+          id: "1",
+          answer: "An answer text",
+          interview: "Speaker A",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].comment).toBe("An answer text");
+    });
+
+    it("should map 'text' to comment", () => {
+      const data = [
+        {
+          id: "1",
+          text: "Some text content",
+          interview: "Speaker A",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].comment).toBe("Some text content");
+    });
+
+    it("should map 'speaker name' to interview", () => {
+      const data = [
+        {
+          id: "1",
+          comment: "A comment",
+          "speaker name": "Speaker A",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].interview).toBe("Speaker A");
+    });
+
+    it("should map 'author' to interview", () => {
+      const data = [
+        {
+          id: "1",
+          comment: "A comment",
+          author: "Author Name",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].interview).toBe("Author Name");
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should throw error when no comment column exists", () => {
+      const invalidData = [
+        {
+          id: "1",
+          someField: "Some value",
+        },
+      ];
+
+      expect(() => formatData(invalidData)).toThrow(
+        /must contain a comment column/,
+      );
+    });
+
+    it("should throw error for empty data", () => {
+      expect(() => formatData([])).toThrow("Invalid or empty data file");
+    });
+
+    it("should throw error for null data", () => {
+      // @ts-expect-error - Testing invalid input type
+      expect(() => formatData(null)).toThrow("Invalid or empty data file");
+    });
+  });
+
+  describe("Optional fields", () => {
+    it("should handle data without interview column", () => {
+      const data = [
+        {
+          id: "1",
+          comment: "A comment without speaker",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0]).toEqual({
+        id: "1",
+        comment: "A comment without speaker",
+      });
+      expect(result[0].interview).toBeUndefined();
+    });
+
+    it("should preserve video and timestamp fields", () => {
+      const data = [
+        {
+          id: "1",
+          comment: "A comment",
+          video: "video-url",
+          timestamp: "00:05:30",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0]).toEqual({
+        id: "1",
+        comment: "A comment",
+        video: "video-url",
+        timestamp: "00:05:30",
+      });
+    });
+  });
+
+  describe("ID column fallback", () => {
+    it("should use row index when no ID column exists", () => {
+      const data = [
+        {
+          comment: "First comment",
+        },
+        {
+          comment: "Second comment",
+        },
+        {
+          comment: "Third comment",
+        },
+      ];
+
+      const result = formatData(data);
+      // When no ID column exists, it falls back to row index
+      expect(result).toHaveLength(3);
+      expect(result[0].id).toBe("0");
+      expect(result[1].id).toBe("1");
+      expect(result[2].id).toBe("2");
+    });
+
+    it("should handle 'row-id' as ID column", () => {
+      const data = [
+        {
+          "row-id": "custom-1",
+          comment: "A comment",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].id).toBe("custom-1");
+    });
+  });
+
+  describe("Column precedence", () => {
+    it("should prefer 'comment' over 'comment-body' when both exist", () => {
+      const data = [
+        {
+          id: "1",
+          comment: "Primary comment",
+          "comment-body": "Secondary comment",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].comment).toBe("Primary comment");
+    });
+
+    it("should prefer 'interview' over 'name' when both exist", () => {
+      const data = [
+        {
+          id: "1",
+          comment: "A comment",
+          interview: "Primary speaker",
+          name: "Secondary speaker",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].interview).toBe("Primary speaker");
+    });
+
+    it("should prefer 'id' over 'comment-id' when both exist", () => {
+      const data = [
+        {
+          id: "primary-id",
+          "comment-id": "secondary-id",
+          comment: "A comment",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].id).toBe("primary-id");
+    });
+  });
+
+  describe("WhatsApp ExtraQuestion1 column", () => {
+    it("should map ExtraQuestion1 to interview field", () => {
+      const data = [
+        {
+          "comment-id": "1",
+          "comment-body": "A comment",
+          ExtraQuestion1: "Speaker from WhatsApp",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].interview).toBe("Speaker from WhatsApp");
+    });
+
+    it("should prefer 'name' over 'ExtraQuestion1' when both exist", () => {
+      const data = [
+        {
+          "comment-id": "1",
+          "comment-body": "A comment",
+          name: "Primary name",
+          ExtraQuestion1: "Secondary name",
+        },
+      ];
+
+      const result = formatData(data);
+      expect(result[0].interview).toBe("Primary name");
+    });
+  });
+});

--- a/express-server/src/routes/create.ts
+++ b/express-server/src/routes/create.ts
@@ -5,7 +5,7 @@ import { fetchSpreadsheetData } from "../googlesheet";
 import { createStorage } from "../storage";
 import * as api from "tttc-common/api";
 import * as schema from "tttc-common/schema";
-import { formatData } from "../utils";
+import { formatData } from "tttc-common/utils";
 import { pipelineQueue } from "../server";
 import * as firebase from "../Firebase";
 import { DecodedIdToken } from "firebase-admin/auth";

--- a/express-server/src/utils.ts
+++ b/express-server/src/utils.ts
@@ -1,5 +1,3 @@
-import { SourceRow } from "tttc-common/schema";
-
 // sync version of sha256 hash to make strong unique urls
 // that do not leak
 const { createHash } = require("crypto");
@@ -23,27 +21,5 @@ export function uniqueSlug(str: string): string {
   return sha256Final;
 }
 
-export function formatData(data: any): SourceRow[] {
-  const ID_COLS = ["id", "Id", "ID", "comment-id", "i"];
-  const COMMENT_COLS = ["comment", "Comment", "comment-body"];
-  if (!data || !data.length) {
-    throw Error("Invalid or empty data file");
-  }
-  const keys = new Set(Object.keys(data[0]));
-  const id_column = ID_COLS.find((x) => keys.has(x));
-  const comment_column = COMMENT_COLS.find((x) => keys.has(x));
-  if (!comment_column) {
-    throw Error(
-      `The csv file must contain a comment column (valid column names: ${COMMENT_COLS.join(", ")})`,
-    );
-  }
-  return data.map((row: any, i: number) => {
-    const id = String({ ...row, i }[id_column!]);
-    const comment = row[comment_column];
-    const res: SourceRow = { id, comment };
-    if (keys.has("video")) res.video = row.video;
-    if (keys.has("interview")) res.interview = row.interview;
-    if (keys.has("timestamp")) res.timestamp = row.timestamp;
-    return res;
-  });
-}
+// Re-export formatData from common for backward compatibility
+export { formatData } from "tttc-common/utils";

--- a/next-client/src/features/submission/actions/SubmitAction.ts
+++ b/next-client/src/features/submission/actions/SubmitAction.ts
@@ -9,15 +9,19 @@ import Papa from "papaparse";
 import { GenerateApiResponse, GenerateApiRequest } from "tttc-common/api";
 import { validatedServerEnv } from "@/server-env";
 import { logger } from "tttc-common/logger/browser";
+import { formatData } from "tttc-common/utils";
 
 const submitActionLogger = logger.child({ module: "submit-action" });
 
 const parseCSV = async (file: File): Promise<SourceRow[]> => {
   const buffer = await file.arrayBuffer();
-  return Papa.parse(Buffer.from(buffer).toString(), {
+  const parseResult = Papa.parse(Buffer.from(buffer).toString(), {
     header: true,
     skipEmptyLines: true,
-  }).data as SourceRow[];
+  });
+
+  // Format raw CSV data to SourceRow format with flexible column mapping
+  return formatData(parseResult.data as Record<string, unknown>[]);
 };
 
 export default async function submitAction(


### PR DESCRIPTION
**1. What is the goal of this PR?**

Address the difference between default outputs of the csv extractor and the default input format. 

**2. What specific parts of T3C are you changing and how?**

CSV parsing, mostly in express-server via common.

**3. How did you test these changes?**

Localy report generation using exports from csv extractor.

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
