### PR TITLE
T3C-523 added server-side analytics to nextjs, logs about and home page

### DIFF
--- a/next-client/src/app/about/page.tsx
+++ b/next-client/src/app/about/page.tsx
@@ -2,8 +2,13 @@ import Icons from "@/assets/icons";
 import { Card, CardContent } from "@/components/elements";
 import { Col, Row } from "@/components/layout";
 import { QuoteText } from "@/components/quote/Quote";
+import { serverSideAnalyticsClient } from "@/lib/analytics/serverSideAnalytics";
 import React from "react";
-
+import {
+  createAnalyticsConfig,
+  getAnalytics,
+  initializeAnalytics,
+} from "tttc-common/analytics";
 const ContentGroup = ({ children }: React.PropsWithChildren) => (
   <Col gap={3}>{children}</Col>
 );
@@ -42,7 +47,9 @@ const Outline = () => (
  * About page for T3C
  * TODO: The spacing between the bullet point and its text is off from the designs. Find a way to control this.
  */
-export default function AboutPage() {
+export default async function AboutPage() {
+  const analytics = await serverSideAnalyticsClient();
+  await analytics.page("About");
   return (
     <Col className="p-8 w-[832px] m-auto">
       <ContentGroupContainer>

--- a/next-client/src/app/page.tsx
+++ b/next-client/src/app/page.tsx
@@ -1,10 +1,13 @@
 import Landing from "@/components/landing/Landing";
+import { serverSideAnalyticsClient } from "@/lib/analytics/serverSideAnalytics";
 
 export function generateStaticParams() {
   return [{ slug: [""] }];
 }
 
-export default function HomePage() {
+export default async function HomePage() {
+  const analytics = await serverSideAnalyticsClient();
+  await analytics.page("Home");
   return (
     <div>
       <Landing />

--- a/next-client/src/lib/analytics/serverSideAnalytics.ts
+++ b/next-client/src/lib/analytics/serverSideAnalytics.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import {
+  createAnalyticsConfig,
+  AnalyticsConfig,
+  initializeAnalytics,
+  getAnalytics,
+} from "tttc-common/analytics";
+
+const config: AnalyticsConfig = createAnalyticsConfig(
+  process.env.NODE_ENV === "development" ? "local" : "posthog",
+  process.env.ANALYTICS_API_KEY,
+  {
+    host: process.env.ANALYTICS_HOST,
+    enabled: Boolean(process.env.ANALYTICS_ENABLED),
+    flushAt: Number(process.env.ANALYTICS_FLUSH_AT),
+    flushInterval: Number(process.env.ANALYTICS_FLUSH_INTERVAL),
+  },
+);
+
+export async function serverSideAnalyticsClient() {
+  await initializeAnalytics(config);
+  const analytics = getAnalytics();
+  return analytics;
+}


### PR DESCRIPTION
Adds server side analytics to the next client, will log when the user visits the about and home pages.

Client side analytics will be added later.

@juggler434 Can you double check to make sure this is working correctly? I do see some logs and I think it works, but I can't test it with posthog proper.