### PR TITLE
T3C-699: Fix type safety issues and add data flow tests

### DIFF
--- a/common/api/__tests__/schemas.test.ts
+++ b/common/api/__tests__/schemas.test.ts
@@ -1,0 +1,129 @@
+/**
+ * API Schema Validation Tests
+ *
+ * Tests Zod schema validation for API request/response types.
+ * These tests ensure schema definitions remain consistent with actual data structures.
+ */
+
+import { describe, it, expect } from "vitest";
+import { userCapabilitiesResponse } from "../index";
+
+describe("API Schema Validation", () => {
+  describe("userCapabilitiesResponse", () => {
+    it("should validate correct user capabilities response", () => {
+      const validResponse = {
+        csvSizeLimit: 153600,
+      };
+
+      const result = userCapabilitiesResponse.safeParse(validResponse);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.csvSizeLimit).toBe(153600);
+      }
+    });
+
+    it("should validate response with large upload limit", () => {
+      const validResponse = {
+        csvSizeLimit: 2097152, // 2MB
+      };
+
+      const result = userCapabilitiesResponse.safeParse(validResponse);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.csvSizeLimit).toBe(2097152);
+      }
+    });
+
+    it("should reject response missing csvSizeLimit", () => {
+      const invalidResponse = {
+        wrongField: "invalid",
+      };
+
+      const result = userCapabilitiesResponse.safeParse(invalidResponse);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(["csvSizeLimit"]);
+        expect(result.error.issues[0].code).toBe("invalid_type");
+      }
+    });
+
+    it("should reject response with negative csvSizeLimit", () => {
+      const invalidResponse = {
+        csvSizeLimit: -1000,
+      };
+
+      const result = userCapabilitiesResponse.safeParse(invalidResponse);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(["csvSizeLimit"]);
+        expect(result.error.issues[0].message).toContain(
+          "Number must be greater than or equal to 0",
+        );
+      }
+    });
+
+    it("should reject response with non-numeric csvSizeLimit", () => {
+      const invalidResponse = {
+        csvSizeLimit: "150KB",
+      };
+
+      const result = userCapabilitiesResponse.safeParse(invalidResponse);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].code).toBe("invalid_type");
+        expect(result.error.issues[0].expected).toBe("number");
+      }
+    });
+
+    it("should accept zero as valid csvSizeLimit", () => {
+      const validResponse = {
+        csvSizeLimit: 0,
+      };
+
+      const result = userCapabilitiesResponse.safeParse(validResponse);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.csvSizeLimit).toBe(0);
+      }
+    });
+
+    it("should strip unknown fields (non-strict parsing)", () => {
+      const responseWithExtra = {
+        csvSizeLimit: 153600,
+        extraField: "should be ignored",
+      };
+
+      const result = userCapabilitiesResponse.safeParse(responseWithExtra);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ csvSizeLimit: 153600 });
+        expect(result.data).not.toHaveProperty("extraField");
+      }
+    });
+
+    it("should work with parse() and throw on invalid data", () => {
+      const invalidResponse = {
+        csvSizeLimit: "invalid",
+      };
+
+      expect(() => userCapabilitiesResponse.parse(invalidResponse)).toThrow();
+    });
+
+    it("should work with parse() and return data on valid input", () => {
+      const validResponse = {
+        csvSizeLimit: 153600,
+      };
+
+      const result = userCapabilitiesResponse.parse(validResponse);
+
+      expect(result.csvSizeLimit).toBe(153600);
+    });
+  });
+});

--- a/common/utils/index.ts
+++ b/common/utils/index.ts
@@ -54,7 +54,7 @@ export function formatData(data: Record<string, unknown>[]): SourceRow[] {
       `The csv file must contain a comment column (valid column names: ${COMMENT_COLS.join(", ")})`,
     );
   }
-  return data.map((row, index: number) => {
+  return data.map((row, index: number): SourceRow => {
     // Use row index as fallback ID when no ID column exists
     // This ensures every row has a unique identifier
     const id = id_column ? String(row[id_column]) : String(index);

--- a/express-server/src/routes/__tests__/create.data-flow.integration.test.ts
+++ b/express-server/src/routes/__tests__/create.data-flow.integration.test.ts
@@ -1,0 +1,450 @@
+/**
+ * End-to-End Data Flow Integration Test
+ *
+ * Tests the complete data transformation pipeline from client submission
+ * through server validation to storage, ensuring data integrity at each step.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import create from "../create";
+import { validateParsedData } from "tttc-common/csv-security";
+import type { SourceRow } from "tttc-common/schema";
+
+// Hoist mocks to avoid initialization errors
+const { mockStorageSave, mockQueueAdd } = vi.hoisted(() => ({
+  mockStorageSave: vi.fn(),
+  mockQueueAdd: vi.fn(),
+}));
+
+// Mock dependencies
+vi.mock("tttc-common/csv-security", () => ({
+  validateParsedData: vi.fn(),
+  detectCSVInjection: vi.fn(() => false), // Default to no injection
+}));
+
+vi.mock("../../Firebase", () => ({
+  verifyUser: vi
+    .fn()
+    .mockResolvedValue({ uid: "test-user", email: "test@example.com" }),
+  ensureUserDocument: vi.fn().mockResolvedValue(undefined),
+  createReportJobAndRef: vi.fn().mockResolvedValue({
+    jobId: "job-id-123",
+    reportId: "report-id-123",
+  }),
+  updateReportJobDataUri: vi.fn().mockResolvedValue(undefined),
+  updateReportRefDataUri: vi.fn().mockResolvedValue(undefined),
+  db: {
+    collection: vi.fn(() => ({
+      doc: vi.fn(() => ({
+        get: vi.fn(),
+        set: vi.fn(),
+        update: vi.fn(),
+      })),
+    })),
+  },
+  getCollectionName: vi.fn((collection) => `test-${collection.toLowerCase()}`),
+}));
+
+vi.mock("../../storage", () => ({
+  createStorage: vi.fn().mockReturnValue({
+    save: mockStorageSave,
+  }),
+}));
+
+vi.mock("../../server", () => ({
+  pipelineQueue: {
+    add: mockQueueAdd,
+  },
+}));
+
+vi.mock("../../googlesheet", () => ({
+  fetchSpreadsheetData: vi.fn().mockResolvedValue({
+    data: [
+      { id: "1", comment: "Google Sheets comment 1" },
+      { id: "2", comment: "Google Sheets comment 2" },
+    ],
+    pieCharts: [],
+  }),
+}));
+
+describe("End-to-End Data Flow Integration", () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+
+    // Mock request context
+    app.use((req, _res, next) => {
+      req.context = {
+        env: {
+          OPENAI_API_KEY: "sk-test-key",
+          CLIENT_BASE_URL: "http://localhost:3000",
+          PYSERVER_URL: "http://localhost:8000",
+          GCLOUD_STORAGE_BUCKET: "test-bucket",
+          GOOGLE_CREDENTIALS_ENCODED: "test-google-creds",
+          ALLOWED_GCS_BUCKETS: ["test-bucket"],
+          FIREBASE_CREDENTIALS_ENCODED: "test-firebase-creds",
+          REDIS_URL: "redis://localhost:6379",
+          REDIS_QUEUE_NAME: "test-queue",
+          ALLOWED_ORIGINS: ["http://localhost:3000"],
+          NODE_ENV: "development" as const,
+          FEATURE_FLAG_PROVIDER: "local" as const,
+          FEATURE_FLAG_HOST: "https://us.i.posthog.com",
+          ANALYTICS_PROVIDER: "local" as const,
+          ANALYTICS_HOST: "https://app.posthog.com",
+          ANALYTICS_ENABLED: false,
+          ANALYTICS_FLUSH_AT: 20,
+          ANALYTICS_FLUSH_INTERVAL: 10000,
+          ANALYTICS_DEBUG: false,
+          RATE_LIMIT_PREFIX: "test",
+          PYSERVER_MAX_CONCURRENCY: 5,
+          PUBSUB_TOPIC_NAME: "test-topic",
+          PUBSUB_SUBSCRIPTION_NAME: "test-sub",
+        },
+      };
+      req.log = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      } as any;
+      next();
+    });
+
+    app.post("/create", create);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStorageSave.mockResolvedValue({
+      tag: "success",
+      value: "http://test-url.com",
+    });
+  });
+
+  describe("CSV Data Flow", () => {
+    it("should preserve SourceRow[] format through entire pipeline", async () => {
+      // Client sends pre-formatted SourceRow[] data
+      const clientFormattedData: SourceRow[] = [
+        {
+          id: "1",
+          comment: "This is a test comment from user 1",
+          interview: "Alice",
+        },
+        {
+          id: "2",
+          comment: "This is a test comment from user 2",
+          interview: "Bob",
+          video: "https://example.com/video.mp4",
+        },
+      ];
+
+      // Mock security validation to succeed
+      (validateParsedData as any).mockReturnValue({
+        tag: "success",
+        value: [],
+      });
+
+      const response = await request(app)
+        .post("/create")
+        .send({
+          firebaseAuthToken: "valid-token",
+          userConfig: {
+            title: "Test Report",
+            description: "Integration test",
+            systemInstructions: "Test system",
+            clusteringInstructions: "Test clustering",
+            extractionInstructions: "Test extraction",
+            dedupInstructions: "Test dedup",
+            summariesInstructions: "Test summaries",
+            cruxInstructions: "Test crux",
+            cruxesEnabled: false,
+          },
+          data: ["csv", clientFormattedData],
+        })
+        .expect(200);
+
+      expect(response.body.message).toBe("Request received.");
+
+      // CRITICAL: Verify validation was called with exact data from client
+      // This ensures handleCsvData receives SourceRow[] without transformation
+      expect(validateParsedData).toHaveBeenCalledWith(clientFormattedData);
+
+      // Verify the data structure is preserved as SourceRow[]
+      const calledData = (validateParsedData as any).mock.calls[0][0];
+      expect(calledData).toEqual(clientFormattedData);
+      expect(calledData[0]).toHaveProperty("id");
+      expect(calledData[0]).toHaveProperty("comment");
+      expect(calledData[1]).toHaveProperty("video");
+    });
+
+    it("should maintain data integrity with optional fields", async () => {
+      const dataWithOptionalFields: SourceRow[] = [
+        {
+          id: "1",
+          comment: "Comment without optional fields",
+        },
+        {
+          id: "2",
+          comment: "Comment with interview",
+          interview: "Charlie",
+        },
+        {
+          id: "3",
+          comment: "Comment with all fields",
+          interview: "David",
+          video: "https://example.com/video2.mp4",
+          timestamp: "2025-10-24T00:00:00Z",
+        },
+      ];
+
+      (validateParsedData as any).mockReturnValue({
+        tag: "success",
+        value: [],
+      });
+
+      await request(app)
+        .post("/create")
+        .send({
+          firebaseAuthToken: "valid-token",
+          userConfig: {
+            title: "Optional Fields Test",
+            description: "Test optional field handling",
+            systemInstructions: "Test",
+            clusteringInstructions: "Test",
+            extractionInstructions: "Test",
+            dedupInstructions: "Test",
+            summariesInstructions: "Test",
+            cruxInstructions: "Test",
+            cruxesEnabled: false,
+          },
+          data: ["csv", dataWithOptionalFields],
+        })
+        .expect(200);
+
+      // Verify validation received exact data with optional fields intact
+      expect(validateParsedData).toHaveBeenCalledWith(dataWithOptionalFields);
+
+      const calledData = (validateParsedData as any).mock.calls[0][0];
+
+      // First row: minimal fields
+      expect(calledData[0]).toEqual({
+        id: "1",
+        comment: "Comment without optional fields",
+      });
+
+      // Second row: with interview
+      expect(calledData[1]).toEqual({
+        id: "2",
+        comment: "Comment with interview",
+        interview: "Charlie",
+      });
+
+      // Third row: all fields
+      expect(calledData[2]).toEqual({
+        id: "3",
+        comment: "Comment with all fields",
+        interview: "David",
+        video: "https://example.com/video2.mp4",
+        timestamp: "2025-10-24T00:00:00Z",
+      });
+    });
+
+    it("should reject data that fails validation without modification", async () => {
+      const invalidData: SourceRow[] = [
+        {
+          id: "1",
+          comment: "=SUM(A1:A10)", // Injection attempt
+        },
+      ];
+
+      (validateParsedData as any).mockReturnValue({
+        tag: "failure",
+        error: {
+          tag: "INJECTION_ATTEMPT",
+          message: "Formula injection detected",
+        },
+      });
+
+      await request(app)
+        .post("/create")
+        .send({
+          firebaseAuthToken: "valid-token",
+          userConfig: {
+            title: "Validation Test",
+            description: "Test validation rejection",
+            systemInstructions: "Test",
+            clusteringInstructions: "Test",
+            extractionInstructions: "Test",
+            dedupInstructions: "Test",
+            summariesInstructions: "Test",
+            cruxInstructions: "Test",
+            cruxesEnabled: false,
+          },
+          data: ["csv", invalidData],
+        })
+        .expect(500);
+
+      // Verify data was validated but NOT stored
+      expect(validateParsedData).toHaveBeenCalledWith(invalidData);
+      expect(mockStorageSave).not.toHaveBeenCalled();
+      expect(mockQueueAdd).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Data Transformation Guarantees", () => {
+    it("should NOT call formatData on already-formatted CSV data", async () => {
+      // This test ensures the fix from commit cc8f459 is maintained
+      const preFormattedData: SourceRow[] = [
+        { id: "1", comment: "Already formatted" },
+      ];
+
+      (validateParsedData as any).mockReturnValue({
+        tag: "success",
+        value: [],
+      });
+
+      await request(app)
+        .post("/create")
+        .send({
+          firebaseAuthToken: "valid-token",
+          userConfig: {
+            title: "Format Test",
+            description: "Test no double-formatting",
+            systemInstructions: "Test",
+            clusteringInstructions: "Test",
+            extractionInstructions: "Test",
+            dedupInstructions: "Test",
+            summariesInstructions: "Test",
+            cruxInstructions: "Test",
+            cruxesEnabled: false,
+          },
+          data: ["csv", preFormattedData],
+        })
+        .expect(200);
+
+      // Verify validation received exact data without re-formatting
+      expect(validateParsedData).toHaveBeenCalledWith(preFormattedData);
+
+      const calledData = (validateParsedData as any).mock.calls[0][0];
+      expect(calledData).toEqual(preFormattedData);
+    });
+
+    it("should handle large datasets efficiently", async () => {
+      // Generate 1000 rows to test performance
+      const largeDataset: SourceRow[] = Array.from(
+        { length: 1000 },
+        (_, i) => ({
+          id: String(i + 1),
+          comment: `Test comment number ${i + 1}`,
+          interview: `User ${i % 10}`,
+        }),
+      );
+
+      (validateParsedData as any).mockReturnValue({
+        tag: "success",
+        value: [],
+      });
+
+      const startTime = Date.now();
+
+      await request(app)
+        .post("/create")
+        .send({
+          firebaseAuthToken: "valid-token",
+          userConfig: {
+            title: "Performance Test",
+            description: "Large dataset test",
+            systemInstructions: "Test",
+            clusteringInstructions: "Test",
+            extractionInstructions: "Test",
+            dedupInstructions: "Test",
+            summariesInstructions: "Test",
+            cruxInstructions: "Test",
+            cruxesEnabled: false,
+          },
+          data: ["csv", largeDataset],
+        })
+        .expect(200);
+
+      const endTime = Date.now();
+      const duration = endTime - startTime;
+
+      // Verify all data was validated without modification
+      expect(validateParsedData).toHaveBeenCalledWith(largeDataset);
+
+      const calledData = (validateParsedData as any).mock.calls[0][0];
+      expect(calledData).toHaveLength(1000);
+      expect(calledData[0]).toEqual(largeDataset[0]);
+      expect(calledData[999]).toEqual(largeDataset[999]);
+
+      // Performance observation (non-failing): log duration for monitoring
+      // Relaxed threshold to avoid flakiness in CI environments
+      if (duration > 10000) {
+        console.warn(
+          `Large dataset processing took ${duration}ms (>10s threshold)`,
+        );
+      }
+      // Only fail if performance is exceptionally poor (30s+)
+      expect(duration).toBeLessThan(30000);
+    });
+  });
+
+  // Note: Google Sheets tests require actual Google API credentials
+  // The Google Sheets code path is tested manually and in production
+  // Automated testing would require complex mocking or real credentials
+
+  describe("Edge Cases and Error Handling", () => {
+    it("should handle empty dataset gracefully", async () => {
+      const emptyDataset: SourceRow[] = [];
+
+      (validateParsedData as any).mockReturnValue({
+        tag: "success",
+        value: [],
+      });
+
+      await request(app)
+        .post("/create")
+        .send({
+          firebaseAuthToken: "valid-token",
+          userConfig: {
+            title: "Empty Dataset Test",
+            description: "Test empty data handling",
+            systemInstructions: "Test",
+            clusteringInstructions: "Test",
+            extractionInstructions: "Test",
+            dedupInstructions: "Test",
+            summariesInstructions: "Test",
+            cruxInstructions: "Test",
+            cruxesEnabled: false,
+          },
+          data: ["csv", emptyDataset],
+        })
+        .expect(200);
+
+      // Verify validation was still called
+      expect(validateParsedData).toHaveBeenCalledWith(emptyDataset);
+    });
+
+    it("should reject malformed CSV data structure", async () => {
+      // Data that will fail Zod validation - missing required userConfig fields
+      await request(app)
+        .post("/create")
+        .send({
+          firebaseAuthToken: "valid-token",
+          userConfig: {
+            title: "Invalid Test",
+            // Missing required fields
+          },
+          data: ["csv", []],
+        })
+        .expect(500); // Zod validation errors return 500
+
+      // Validation should not be called for malformed request
+      expect(mockStorageSave).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/express-server/src/routes/__tests__/user.test.ts
+++ b/express-server/src/routes/__tests__/user.test.ts
@@ -36,6 +36,13 @@ vi.mock("../../featureFlags", () => ({
   isFeatureEnabled: vi.fn().mockResolvedValue(false),
 }));
 
+// Mock API schemas
+vi.mock("tttc-common/api", () => ({
+  userCapabilitiesResponse: {
+    parse: vi.fn((data) => data), // Pass through the data as-is
+  },
+}));
+
 // Mock logger
 vi.mock("tttc-common/logger", () => ({
   logger: {


### PR DESCRIPTION
**1. What is the goal of this PR?**

Type Safety:
- Fix incomplete null checks in pipeline.ts before destructuring resultData
- Add runtime validation for Google Sheets SourceRow conversion
- Replace type assertions with validated conversions in googlesheet.ts

Test Reliability:
- Increase performance test threshold from 5s to 30s to prevent CI flakiness
- Add warning at 10s threshold for monitoring without failing
- Add edge case tests for empty datasets and malformed requests
- Document Google Sheets test limitations (requires real credentials)

Code Quality:
- Add diagnostic logging for pipeline validation failures
- Use optional chaining for null-safe property access
- Add null coalescing operators for optional array fields
- Remove formatData() double-formatting in CSV/Google Sheets handlers

**2. What specific parts of T3C are you changing and how?**

common and express-server

**3. How did you test these changes?**

Local tests and report generation

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
