### PR TITLE
T3C-784: Extract Report components for better organization

### DIFF
--- a/next-client/src/components/report/Report.stories.tsx
+++ b/next-client/src/components/report/Report.stories.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { reportData } from "../../../stories/data/dummyData";
-import Report, {
+import Report from "./Report";
+import {
   ReportHeader,
   ReportOverview,
   ReportSummary,
   ReportTitle,
-} from "./Report";
+} from "./components/ReportHeader";
 import { getNPeople } from "tttc-common/morphisms";
 import * as schema from "tttc-common/schema";
 import jsonData from "../../../stories/data/healMichigan.json";

--- a/next-client/src/components/report/components/ReportLayout.tsx
+++ b/next-client/src/components/report/components/ReportLayout.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { Col, Row } from "@/components/layout";
+import { Sheet, SheetContent, SheetTitle } from "@/components/elements";
+import { Sticky } from "@/components/wrappers";
+import { cn } from "@/lib/utils/shadcn";
+
+/**
+ * Frame that wraps the toolbar.
+ * When the user scrolls down, it enters sticky mode and floats above the rest of the content.
+ */
+export const ToolBarFrame = ({
+  children,
+  className,
+  stickyClass,
+}: React.PropsWithChildren<{ className?: string; stickyClass?: string }>) => (
+  <Sticky
+    className={cn(
+      `z-[70] w-full dark:bg-background bg-white pointer-events-auto`,
+      className,
+    )}
+    stickyClass={cn("border-b shadow-sm pointer-events-auto", stickyClass)}
+  >
+    {children}
+  </Sticky>
+);
+
+/**
+ * The report page is divided into three sections:
+ * - The outline (to the left)
+ * - The main report body (center)
+ * - A blank space to the right for balance
+ *
+ * The outline is hidden when on the Cruxes tab.
+ */
+export function ReportLayout({
+  Outline,
+  Report,
+  ToolBar,
+  isMobileOutlineOpen,
+  setIsMobileOutlineOpen,
+  navbarState,
+  activeContentTab,
+}: {
+  Outline: React.ReactNode;
+  Report: React.ReactNode;
+  ToolBar: React.ReactNode;
+  isMobileOutlineOpen: boolean;
+  setIsMobileOutlineOpen: (val: boolean) => void;
+  navbarState: { isVisible: boolean; height: number };
+  activeContentTab: "report" | "cruxes";
+}) {
+  const showOutline = activeContentTab === "report";
+
+  return (
+    <Row className="flex w-full min-h-screen">
+      {/* Outline section - keep column for layout but hide content on cruxes tab */}
+      <Col className="hidden md:block min-w-[279px] basis-0 flex-grow">
+        <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
+          <div className="w-full h-14" />
+        </ToolBarFrame>
+        <div
+          className={cn(
+            "sticky top-20",
+            !showOutline && "opacity-0 pointer-events-none",
+          )}
+        >
+          {Outline}
+        </div>
+      </Col>
+
+      {/* Mobile outline sheet - only show on report tab */}
+      {showOutline && (
+        <Sheet open={isMobileOutlineOpen} onOpenChange={setIsMobileOutlineOpen}>
+          <SheetContent side={"left"} className="px-0 pt-0 top-0 max-w-[280px]">
+            <div
+              className="border-t border-l border-slate-200 h-[calc(100vh-theme(spacing.14))] transition-all duration-200 pt-4 pr-2"
+              style={{
+                marginTop: navbarState.isVisible
+                  ? `${navbarState.height + 56}px`
+                  : "56px", // 56px is toolbar height (h-14)
+                height: navbarState.isVisible
+                  ? `calc(100vh - ${navbarState.height + 56}px)`
+                  : "calc(100vh - 56px)",
+              }}
+            >
+              {/* Sheet title here is a requirement for visually impaired users. Won't show up visually. */}
+              <SheetTitle className="sr-only">Outline</SheetTitle>
+              {Outline}
+            </div>
+          </SheetContent>
+        </Sheet>
+      )}
+
+      {/* Body section */}
+      <Col className="flex-grow max-w-[896px] mx-auto w-full">
+        <ToolBarFrame>{ToolBar}</ToolBarFrame>
+        {Report}
+      </Col>
+
+      {/* Right section - spacer for balanced layout */}
+      <Col className="min-w-[279px] basis-0 flex-grow hidden sm:block">
+        <ToolBarFrame className="opacity-0" stickyClass="opacity-100">
+          <div className="w-full h-14" />
+        </ToolBarFrame>
+      </Col>
+    </Row>
+  );
+}

--- a/next-client/src/components/report/components/ReportToolbar.tsx
+++ b/next-client/src/components/report/components/ReportToolbar.tsx
@@ -1,0 +1,63 @@
+import React, { useContext } from "react";
+import { Row } from "@/components/layout";
+import { Button } from "@/components/elements";
+import Icons from "@/assets/icons";
+import { cn } from "@/lib/utils/shadcn";
+import { ReportContext } from "../Report";
+
+/**
+ * Toolbar that follows down screen. Lets user do certain actions.
+ * Buttons are hidden when on the Cruxes tab.
+ */
+export function ReportToolbar({
+  setIsMobileOutlineOpen,
+  isMobileOutlineOpen,
+}: {
+  setIsMobileOutlineOpen: (val: boolean) => void;
+  isMobileOutlineOpen: boolean;
+}) {
+  const { dispatch, activeContentTab } = useContext(ReportContext);
+
+  return (
+    <Row
+      // h-14 ensures consistent height with side column spacers when buttons are hidden
+      className={`p-2 h-14 justify-between w-full mx-auto`}
+    >
+      {/* Left side - mobile outline toggle */}
+      <Row gap={2} className={cn(activeContentTab !== "report" && "hidden")}>
+        <div>
+          <Button
+            onClick={() => setIsMobileOutlineOpen(!isMobileOutlineOpen)}
+            className="sm:hidden p-3"
+            variant={"outline"}
+          >
+            {isMobileOutlineOpen ? (
+              <Icons.X2 className="fill-muted-foreground" />
+            ) : (
+              <Icons.MobileOutline className="size-4 fill-muted-foreground" />
+            )}
+          </Button>
+        </div>
+      </Row>
+
+      {/* Right side - expand/collapse buttons */}
+      <Row gap={2} className={cn(activeContentTab !== "report" && "hidden")}>
+        {/* Close all button */}
+        <Button
+          onClick={() => dispatch({ type: "closeAll" })}
+          variant={"outline"}
+        >
+          Collapse all
+        </Button>
+        {/* Open all button */}
+        <Button
+          onClick={() => dispatch({ type: "openAll" })}
+          variant={"secondary"}
+          data-testid={"open-all-button"}
+        >
+          Expand all
+        </Button>
+      </Row>
+    </Row>
+  );
+}

--- a/next-client/src/components/subtopic/Subtopic.stories.tsx
+++ b/next-client/src/components/subtopic/Subtopic.stories.tsx
@@ -24,6 +24,7 @@ const meta = {
           setScrollTo: () => null,
           useReportEffect: () => {},
           useFocusedNode: () => ({}) as Ref<HTMLDivElement>,
+          useFocusedNodeForCruxes: () => ({}) as Ref<HTMLDivElement>,
           addOns: reportData.addons,
           sortByControversy: false,
           setSortByControversy: () => null,
@@ -32,6 +33,8 @@ const meta = {
           activeContentTab: "report",
           setActiveContentTab: () => null,
           getTopicColor: () => undefined,
+          getSubtopicId: () => null,
+          focusedCruxId: null,
         }}
       >
         <TopicContext.Provider
@@ -52,5 +55,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Main: Story = {
-  args: { subtopicNode: subtopicNode, onExpandSubtopic: () => null },
+  args: {
+    subtopicNode: subtopicNode,
+    topicTitle: topicNode.data.title,
+    topicColor: topicNode.data.topicColor,
+    show: true,
+  },
 };

--- a/next-client/src/components/subtopic/Subtopic.tsx
+++ b/next-client/src/components/subtopic/Subtopic.tsx
@@ -34,11 +34,49 @@ import {
   AgreeDisagreeSpectrum,
 } from "@/components/controversy";
 import { ControversyIcon } from "@/assets/icons/ControversyIcons";
+import { mergeRefs } from "react-merge-refs";
 
 /**
- * UI for subtopic
+ * Second highest level node in a Report. Expands to show claims.
+ * This wrapper handles scroll/focus refs and visibility.
  */
-export const Subtopic = forwardRef<
+export function Subtopic({
+  subtopicNode,
+  topicTitle,
+  topicColor,
+  show,
+}: {
+  subtopicNode: SubtopicNode;
+  topicTitle: string;
+  topicColor?: string;
+  show: boolean;
+}) {
+  const { useScrollTo, useFocusedNode, dispatch } = useContext(ReportContext);
+
+  const scrollRef = useScrollTo(subtopicNode.data.id);
+  const focusedRef = useFocusedNode(subtopicNode.data.id, !show);
+
+  if (!show) {
+    return <></>;
+  }
+
+  return (
+    <SubtopicCard
+      subtopicNode={subtopicNode}
+      topicTitle={topicTitle}
+      topicColor={topicColor}
+      ref={mergeRefs([scrollRef, focusedRef])}
+      onExpandSubtopic={() =>
+        dispatch({ type: "expandSubtopic", payload: { id: subtopicNode.id } })
+      }
+    />
+  );
+}
+
+/**
+ * UI for subtopic card
+ */
+export const SubtopicCard = forwardRef<
   HTMLDivElement,
   {
     subtopicNode: SubtopicNode;

--- a/next-client/src/components/topic/Topic.tsx
+++ b/next-client/src/components/topic/Topic.tsx
@@ -18,7 +18,7 @@ import { CopyLinkButton } from "../copyButton/CopyButton";
 import { PointGraphicGroup } from "../pointGraphic/PointGraphic";
 import Icons from "@/assets/icons";
 import { Col, Row } from "../layout";
-import Subtopic, { SubtopicHeader } from "../subtopic/Subtopic";
+import { Subtopic, SubtopicHeader } from "../subtopic/Subtopic";
 import { getNClaims, getNPeople } from "tttc-common/morphisms";
 import useGroupHover from "../pointGraphic/hooks/useGroupHover";
 import { ReportContext } from "../report/Report";
@@ -292,8 +292,10 @@ function ExpandTopic() {
       )}
       <Col className="px-3 sm:px-8 gap-y-4">
         {subtopicNodes.map((node, i) => (
-          <SubtopicItem
+          <Subtopic
             subtopicNode={node}
+            topicTitle={data.title}
+            topicColor={data.topicColor}
             show={isOpen && i <= pagination}
             key={node.id}
           />
@@ -309,36 +311,6 @@ function ExpandTopic() {
         </>
       )}
     </Col>
-  );
-}
-
-function SubtopicItem({
-  subtopicNode,
-  show,
-}: {
-  subtopicNode: SubtopicNode;
-  show: boolean;
-}) {
-  const { useScrollTo, useFocusedNode, dispatch } = useContext(ReportContext);
-  const { topicNode } = useContext(TopicContext);
-
-  const scrollRef = useScrollTo(subtopicNode.data.id);
-  const focusedRef = useFocusedNode(subtopicNode.data.id, !show);
-
-  if (!show) {
-    return <></>;
-  }
-
-  return (
-    <Subtopic
-      subtopicNode={subtopicNode}
-      topicTitle={topicNode.data.title}
-      topicColor={topicNode.data.topicColor}
-      ref={mergeRefs([scrollRef, focusedRef])}
-      onExpandSubtopic={() =>
-        dispatch({ type: "expandSubtopic", payload: { id: subtopicNode.id } })
-      }
-    />
   );
 }
 


### PR DESCRIPTION
**1. What is the goal of this PR?**

Refactor Report.tsx by extracting components into separate files:
- ReportLayout.tsx: Three-column layout with tab-aware outline visibility
- ReportHeader.tsx: Title, stats, summary, and overview components
- ReportToolbar.tsx: Expand/collapse buttons with tab awareness

Also move SubtopicItem wrapper logic from Topic.tsx into Subtopic.tsx, creating a cleaner separation of concerns.

This reduces Report.tsx from ~1063 lines to ~679 lines.

Based on organizational improvements proposed by Brandon Perry in PR #390.

**2. What specific parts of T3C are you changing and how?**

next-client

**3. How did you test these changes?**

Locally

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
