### PR TITLE
T3C-787: Add user-friendly error pages

### DIFF
--- a/common/api/index.ts
+++ b/common/api/index.ts
@@ -60,3 +60,18 @@ export const userCapabilitiesResponse = z.object({
 });
 
 export type UserCapabilitiesResponse = z.infer<typeof userCapabilitiesResponse>;
+
+// Form action result types for Next.js server actions
+export const formActionError = z.object({
+  code: z.string(),
+  message: z.string(),
+  /** Unique request ID for correlating with server logs */
+  requestId: z.string().optional(),
+});
+
+export type FormActionError = z.infer<typeof formActionError>;
+
+export type CreateReportActionResult =
+  | { status: "idle" }
+  | { status: "success"; data: GenerateApiResponse }
+  | { status: "error"; error: FormActionError };

--- a/common/errors/index.ts
+++ b/common/errors/index.ts
@@ -1,0 +1,173 @@
+/**
+ * Shared error codes and user-friendly messages for the Talk to the City API.
+ *
+ * These codes are used by both the Express server (for consistent error responses)
+ * and the Next.js client (for displaying appropriate error messages).
+ */
+
+/**
+ * Standard error codes used across the application.
+ * Each code maps to an HTTP status category and a user-friendly message.
+ */
+export const ERROR_CODES = {
+  // Authentication errors (401/403)
+  AUTH_TOKEN_MISSING: "AUTH_TOKEN_MISSING",
+  AUTH_TOKEN_INVALID: "AUTH_TOKEN_INVALID",
+  AUTH_TOKEN_EXPIRED: "AUTH_TOKEN_EXPIRED",
+  AUTH_EMAIL_NOT_VERIFIED: "AUTH_EMAIL_NOT_VERIFIED",
+  AUTH_UNAUTHORIZED: "AUTH_UNAUTHORIZED",
+
+  // Validation errors (400)
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  INVALID_REQUEST: "INVALID_REQUEST",
+  CSV_TOO_LARGE: "CSV_TOO_LARGE",
+  CSV_INVALID_FORMAT: "CSV_INVALID_FORMAT",
+  CSV_SECURITY_VIOLATION: "CSV_SECURITY_VIOLATION",
+  INVALID_REPORT_URI: "INVALID_REPORT_URI",
+
+  // Resource errors (404)
+  REPORT_NOT_FOUND: "REPORT_NOT_FOUND",
+  USER_NOT_FOUND: "USER_NOT_FOUND",
+
+  // Rate limiting (429)
+  RATE_LIMIT_EXCEEDED: "RATE_LIMIT_EXCEEDED",
+
+  // Server errors (500)
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+  PIPELINE_FAILED: "PIPELINE_FAILED",
+  STORAGE_ERROR: "STORAGE_ERROR",
+  SERVICE_UNAVAILABLE: "SERVICE_UNAVAILABLE",
+  DATABASE_ERROR: "DATABASE_ERROR",
+} as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+
+/**
+ * User-friendly error messages for each error code.
+ * These messages are safe to display to end users and don't expose internal details.
+ */
+export const ERROR_MESSAGES: Record<ErrorCode, string> = {
+  // Authentication
+  [ERROR_CODES.AUTH_TOKEN_MISSING]: "Please sign in to continue.",
+  [ERROR_CODES.AUTH_TOKEN_INVALID]:
+    "Your session is invalid. Please sign in again.",
+  [ERROR_CODES.AUTH_TOKEN_EXPIRED]:
+    "Your session has expired. Please sign in again.",
+  [ERROR_CODES.AUTH_EMAIL_NOT_VERIFIED]:
+    "Please verify your email address to continue. Check your inbox for a verification link.",
+  [ERROR_CODES.AUTH_UNAUTHORIZED]:
+    "You don't have permission to perform this action.",
+
+  // Validation
+  [ERROR_CODES.VALIDATION_ERROR]:
+    "The request contains invalid data. Please check your input.",
+  [ERROR_CODES.INVALID_REQUEST]: "The request format is invalid.",
+  [ERROR_CODES.CSV_TOO_LARGE]:
+    "The file is too large. Please upload a smaller file.",
+  [ERROR_CODES.CSV_INVALID_FORMAT]:
+    "The file format isn't recognized. Please ensure it's a valid CSV file.",
+  [ERROR_CODES.CSV_SECURITY_VIOLATION]:
+    "The file contains content that can't be processed. Please check the file and try again.",
+  [ERROR_CODES.INVALID_REPORT_URI]: "The report address is invalid.",
+
+  // Resources
+  [ERROR_CODES.REPORT_NOT_FOUND]:
+    "We couldn't find that report. It may have been deleted or moved.",
+  [ERROR_CODES.USER_NOT_FOUND]: "User account not found.",
+
+  // Rate limiting
+  [ERROR_CODES.RATE_LIMIT_EXCEEDED]:
+    "You're making requests too quickly. Please wait a moment and try again.",
+
+  // Server
+  [ERROR_CODES.INTERNAL_ERROR]:
+    "Something went wrong on our end. Please try again.",
+  [ERROR_CODES.PIPELINE_FAILED]:
+    "Report generation failed. Please try again or contact support if the problem persists.",
+  [ERROR_CODES.STORAGE_ERROR]: "Unable to access the report. Please try again.",
+  [ERROR_CODES.SERVICE_UNAVAILABLE]:
+    "Our service is temporarily unavailable. Please try again in a few minutes.",
+  [ERROR_CODES.DATABASE_ERROR]:
+    "Unable to access the database. Please try again.",
+};
+
+/**
+ * HTTP status codes associated with each error code.
+ */
+export const ERROR_STATUS_CODES: Record<ErrorCode, number> = {
+  // Authentication - 401/403
+  [ERROR_CODES.AUTH_TOKEN_MISSING]: 401,
+  [ERROR_CODES.AUTH_TOKEN_INVALID]: 401,
+  [ERROR_CODES.AUTH_TOKEN_EXPIRED]: 401,
+  [ERROR_CODES.AUTH_EMAIL_NOT_VERIFIED]: 403,
+  [ERROR_CODES.AUTH_UNAUTHORIZED]: 403,
+
+  // Validation - 400
+  [ERROR_CODES.VALIDATION_ERROR]: 400,
+  [ERROR_CODES.INVALID_REQUEST]: 400,
+  [ERROR_CODES.CSV_TOO_LARGE]: 400,
+  [ERROR_CODES.CSV_INVALID_FORMAT]: 400,
+  [ERROR_CODES.CSV_SECURITY_VIOLATION]: 400,
+  [ERROR_CODES.INVALID_REPORT_URI]: 400,
+
+  // Resources - 404
+  [ERROR_CODES.REPORT_NOT_FOUND]: 404,
+  [ERROR_CODES.USER_NOT_FOUND]: 404,
+
+  // Rate limiting - 429
+  [ERROR_CODES.RATE_LIMIT_EXCEEDED]: 429,
+
+  // Server - 500
+  [ERROR_CODES.INTERNAL_ERROR]: 500,
+  [ERROR_CODES.PIPELINE_FAILED]: 500,
+  [ERROR_CODES.STORAGE_ERROR]: 500,
+  [ERROR_CODES.SERVICE_UNAVAILABLE]: 503,
+  [ERROR_CODES.DATABASE_ERROR]: 500,
+};
+
+/**
+ * Get the user-friendly message for an error code.
+ * Falls back to a generic message if the code is unknown.
+ */
+export function getErrorMessage(code: string): string {
+  return (
+    ERROR_MESSAGES[code as ErrorCode] ??
+    "Something went wrong. Please try again."
+  );
+}
+
+/**
+ * Get the HTTP status code for an error code.
+ * Falls back to 500 if the code is unknown.
+ */
+export function getErrorStatusCode(code: string): number {
+  return ERROR_STATUS_CODES[code as ErrorCode] ?? 500;
+}
+
+/**
+ * Standard API error response structure.
+ */
+export interface ApiErrorResponse {
+  error: {
+    message: string;
+    code: ErrorCode;
+    requestId?: string;
+  };
+}
+
+/**
+ * Create a standardized error response object.
+ */
+export function createErrorResponse(
+  code: ErrorCode,
+  requestId?: string,
+  customMessage?: string,
+): ApiErrorResponse {
+  return {
+    error: {
+      message: customMessage ?? ERROR_MESSAGES[code],
+      code,
+      ...(requestId ? { requestId } : {}),
+    },
+  };
+}

--- a/common/package.json
+++ b/common/package.json
@@ -70,6 +70,10 @@
     "./evaluations/*/scorers": {
       "types": "./dist/evaluations/*/scorers.d.ts",
       "default": "./dist/evaluations/*/scorers.js"
+    },
+    "./errors": {
+      "types": "./dist/errors/index.d.ts",
+      "default": "./dist/errors/index.js"
     }
   },
   "engines": {

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -25,6 +25,7 @@
     "./apiPyserver/*",
     "./csv-security/*",
     "./csv-validation/*",
+    "./errors/*",
     "./evaluations/**/*",
     "./feature-flags/**/*",
     "./firebase/*",

--- a/express-server/src/routes/__tests__/authEvents.test.ts
+++ b/express-server/src/routes/__tests__/authEvents.test.ts
@@ -3,7 +3,7 @@ import { Response } from "express";
 import { RequestWithLogger } from "../../types/request";
 import authEvents from "../authEvents";
 import { verifyUser } from "../../Firebase";
-import { sendError } from "../sendError.js";
+import { sendError, sendErrorByCode } from "../sendError.js";
 import { Logger } from "pino";
 
 // Mock Firebase functions
@@ -11,9 +11,10 @@ vi.mock("../../Firebase", () => ({
   verifyUser: vi.fn(),
 }));
 
-// Mock sendError utility
+// Mock sendError utilities
 vi.mock("../sendError.js", () => ({
   sendError: vi.fn(),
+  sendErrorByCode: vi.fn(),
 }));
 
 // Mock logger
@@ -134,12 +135,11 @@ describe("Auth Events Route", () => {
       // Act
       await authEvents(mockRequest, mockResponse as Response);
 
-      // Assert
-      expect(mockSendError).toHaveBeenCalledWith(
+      // Assert - now uses sendErrorByCode with standardized error codes
+      expect(vi.mocked(sendErrorByCode)).toHaveBeenCalledWith(
         mockResponse,
-        400,
-        "Invalid request format",
-        "ValidationError",
+        "VALIDATION_ERROR",
+        mockRequest.log,
       );
     });
 
@@ -154,12 +154,11 @@ describe("Auth Events Route", () => {
       // Act
       await authEvents(mockRequest, mockResponse as Response);
 
-      // Assert
-      expect(mockSendError).toHaveBeenCalledWith(
+      // Assert - now uses sendErrorByCode with standardized error codes
+      expect(vi.mocked(sendErrorByCode)).toHaveBeenCalledWith(
         mockResponse,
-        400,
-        "Invalid event or missing token",
-        "ValidationError",
+        "VALIDATION_ERROR",
+        mockRequest.log,
       );
     });
 
@@ -178,12 +177,11 @@ describe("Auth Events Route", () => {
       // Act
       await authEvents(mockRequest, mockResponse as Response);
 
-      // Assert
-      expect(mockSendError).toHaveBeenCalledWith(
+      // Assert - token errors return AUTH_TOKEN_INVALID, not INTERNAL_ERROR
+      expect(vi.mocked(sendErrorByCode)).toHaveBeenCalledWith(
         mockResponse,
-        500,
-        "Invalid token",
-        "AuthEventError",
+        "AUTH_TOKEN_INVALID",
+        mockRequest.log,
       );
     });
 
@@ -197,12 +195,11 @@ describe("Auth Events Route", () => {
       // Act
       await authEvents(mockRequest, mockResponse as Response);
 
-      // Assert
-      expect(mockSendError).toHaveBeenCalledWith(
+      // Assert - now uses sendErrorByCode with standardized error codes
+      expect(vi.mocked(sendErrorByCode)).toHaveBeenCalledWith(
         mockResponse,
-        400,
-        "Invalid request format",
-        "ValidationError",
+        "VALIDATION_ERROR",
+        mockRequest.log,
       );
     });
 

--- a/express-server/src/routes/__tests__/create.csv-security.test.ts
+++ b/express-server/src/routes/__tests__/create.csv-security.test.ts
@@ -173,11 +173,13 @@ describe("CSV Security in Create Route", () => {
     const response = await request(app)
       .post("/create")
       .send(createValidRequestBody(maliciousData))
-      .expect(500);
+      .expect(400);
 
-    expect(response.body.error.message).toContain(
-      "CSV security validation failed",
+    // CSV security violations return 400 with specific error code
+    expect(response.body.error.message).toBe(
+      "The file contains content that can't be processed. Please check the file and try again.",
     );
+    expect(response.body.error.code).toBe("CSV_SECURITY_VIOLATION");
     expect(validateParsedData).toHaveBeenCalledWith(maliciousData);
   });
 
@@ -191,11 +193,13 @@ describe("CSV Security in Create Route", () => {
     const response = await request(app)
       .post("/create")
       .send(createValidRequestBody(maliciousData))
-      .expect(500);
+      .expect(400);
 
-    expect(response.body.error.message).toContain(
-      "Potential injection detected in comment field",
+    // CSV security violations return 400 with specific error code
+    expect(response.body.error.message).toBe(
+      "The file contains content that can't be processed. Please check the file and try again.",
     );
+    expect(response.body.error.code).toBe("CSV_SECURITY_VIOLATION");
     expect(detectCSVInjection).toHaveBeenCalledWith("=SUM(A1:A10)");
   });
 
@@ -209,11 +213,13 @@ describe("CSV Security in Create Route", () => {
     const response = await request(app)
       .post("/create")
       .send(createValidRequestBody(maliciousData))
-      .expect(500);
+      .expect(400);
 
-    expect(response.body.error.message).toContain(
-      "Potential injection detected in interview field",
+    // CSV security violations return 400 with specific error code
+    expect(response.body.error.message).toBe(
+      "The file contains content that can't be processed. Please check the file and try again.",
     );
+    expect(response.body.error.code).toBe("CSV_SECURITY_VIOLATION");
     expect(detectCSVInjection).toHaveBeenCalledWith("javascript:alert(1)");
   });
 
@@ -270,12 +276,13 @@ describe("CSV Security in Create Route", () => {
     const response = await request(app)
       .post("/create")
       .send(createValidRequestBody(testData))
-      .expect(500);
+      .expect(400);
 
-    expect(response.body.error.message).toContain(
-      "CSV security validation failed",
+    // CSV security violations return 400 with specific error code
+    expect(response.body.error.message).toBe(
+      "The file contains content that can't be processed. Please check the file and try again.",
     );
-    expect(response.body.error.message).toContain("MALFORMED_STRUCTURE");
+    expect(response.body.error.code).toBe("CSV_SECURITY_VIOLATION");
   });
 
   it("should receive CSV data in SourceRow[] format from client", async () => {

--- a/express-server/src/routes/__tests__/create.data-flow.integration.test.ts
+++ b/express-server/src/routes/__tests__/create.data-flow.integration.test.ts
@@ -286,7 +286,7 @@ describe("End-to-End Data Flow Integration", () => {
           },
           data: ["csv", invalidData],
         })
-        .expect(500);
+        .expect(400); // CSV security violations are client errors (400), not server errors (500)
 
       // Verify data was validated but NOT stored
       expect(validateParsedData).toHaveBeenCalledWith(invalidData);

--- a/express-server/src/routes/__tests__/user.test.ts
+++ b/express-server/src/routes/__tests__/user.test.ts
@@ -48,6 +48,7 @@ vi.mock("tttc-common/logger", () => ({
   logger: {
     child: vi.fn(() => ({
       info: vi.fn(),
+      warn: vi.fn(),
       error: vi.fn(),
     })),
   },
@@ -143,7 +144,8 @@ describe("getUserLimits", () => {
     expect(mockRes.status).toHaveBeenCalledWith(401);
     expect(mockRes.json).toHaveBeenCalledWith({
       error: {
-        message: "No authorization token provided",
+        message: "Please sign in to continue.",
+        code: "AUTH_TOKEN_MISSING",
       },
     });
   });
@@ -156,7 +158,8 @@ describe("getUserLimits", () => {
     expect(mockRes.status).toHaveBeenCalledWith(401);
     expect(mockRes.json).toHaveBeenCalledWith({
       error: {
-        message: "Invalid authorization token",
+        message: "Your session is invalid. Please sign in again.",
+        code: "AUTH_TOKEN_INVALID",
       },
     });
   });
@@ -181,7 +184,8 @@ describe("getUserLimits", () => {
     expect(mockRes.status).toHaveBeenCalledWith(500);
     expect(mockRes.json).toHaveBeenCalledWith({
       error: {
-        message: "Failed to retrieve user limits",
+        message: "Something went wrong on our end. Please try again.",
+        code: "INTERNAL_ERROR",
       },
     });
   });

--- a/express-server/src/routes/sendError.ts
+++ b/express-server/src/routes/sendError.ts
@@ -1,5 +1,10 @@
 import { Response } from "express";
 import { Logger } from "pino";
+import {
+  ErrorCode,
+  getErrorStatusCode,
+  createErrorResponse,
+} from "tttc-common/errors";
 
 /**
  * Sends a consistent JSON error response.
@@ -8,6 +13,8 @@ import { Logger } from "pino";
  * @param message Error message
  * @param errorCode Optional error code
  * @param logger Optional logger for error tracking
+ * @param requestId Optional request ID for log correlation
+ * @deprecated Use sendErrorByCode() for new code to ensure consistent error messages
  */
 export function sendError(
   res: Response,
@@ -15,15 +22,49 @@ export function sendError(
   message: string,
   errorCode?: string,
   logger?: Logger,
+  requestId?: string,
 ) {
   if (logger) {
-    logger.warn({ status, message, errorCode }, "Sending error response");
+    logger.warn(
+      { status, message, errorCode, requestId },
+      "Sending error response",
+    );
   }
 
   res.status(status).json({
     error: {
       message,
       ...(errorCode ? { code: errorCode } : {}),
+      ...(requestId ? { requestId } : {}),
     },
   });
+}
+
+/**
+ * Sends an error response using standardized error codes.
+ * Automatically uses the correct HTTP status code and user-friendly message.
+ * @param res Express response object
+ * @param code Standardized error code from ERROR_CODES
+ * @param logger Optional logger for error tracking
+ * @param requestId Optional request ID for log correlation
+ */
+export function sendErrorByCode(
+  res: Response,
+  code: ErrorCode,
+  logger?: Logger,
+  requestId?: string,
+) {
+  const status = getErrorStatusCode(code);
+  const errorResponse = createErrorResponse(code, requestId);
+
+  if (logger) {
+    // Use error level for 500s, warn for client errors
+    if (status >= 500) {
+      logger.error({ status, code, requestId }, "Sending error response");
+    } else {
+      logger.warn({ status, code, requestId }, "Sending error response");
+    }
+  }
+
+  res.status(status).json(errorResponse);
 }

--- a/express-server/src/routes/user.ts
+++ b/express-server/src/routes/user.ts
@@ -3,7 +3,8 @@ import { RequestWithLogger } from "../types/request";
 import * as firebase from "../Firebase";
 import { logger } from "tttc-common/logger";
 import { getUserCapabilities } from "tttc-common/permissions";
-import { sendError } from "./sendError";
+import { sendErrorByCode } from "./sendError";
+import { ERROR_CODES } from "tttc-common/errors";
 import * as api from "tttc-common/api";
 
 const userLogger = logger.child({ module: "user" });
@@ -21,7 +22,7 @@ export async function getUserLimits(
     const authToken = req.headers.authorization?.replace("Bearer ", "");
 
     if (!authToken) {
-      sendError(res, 401, "No authorization token provided");
+      sendErrorByCode(res, ERROR_CODES.AUTH_TOKEN_MISSING, userLogger);
       return;
     }
 
@@ -29,7 +30,7 @@ export async function getUserLimits(
     const decodedUser = await firebase.verifyUser(authToken);
 
     if (!decodedUser) {
-      sendError(res, 401, "Invalid authorization token");
+      sendErrorByCode(res, ERROR_CODES.AUTH_TOKEN_INVALID, userLogger);
       return;
     }
 
@@ -59,6 +60,6 @@ export async function getUserLimits(
     res.json(validatedResponse);
   } catch (error) {
     userLogger.error({ error }, "Failed to get user limits");
-    sendError(res, 500, "Failed to retrieve user limits");
+    sendErrorByCode(res, ERROR_CODES.INTERNAL_ERROR, userLogger);
   }
 }

--- a/express-server/src/server.ts
+++ b/express-server/src/server.ts
@@ -31,6 +31,11 @@ import {
   initializeAnalyticsClient,
   shutdownAnalyticsClient,
 } from "./analytics";
+import {
+  ERROR_CODES,
+  ERROR_MESSAGES,
+  getErrorStatusCode,
+} from "tttc-common/errors";
 
 const serverLogger = logger.child({ module: "server" });
 
@@ -155,10 +160,10 @@ const createRateLimitHandler = (
       message,
     );
 
-    res.status(429).json({
+    res.status(getErrorStatusCode(ERROR_CODES.RATE_LIMIT_EXCEEDED)).json({
       error: {
-        message: "Too many requests, please try again later.",
-        code: "RateLimitExceeded",
+        message: ERROR_MESSAGES[ERROR_CODES.RATE_LIMIT_EXCEEDED],
+        code: ERROR_CODES.RATE_LIMIT_EXCEEDED,
         retryAfter: Math.ceil(windowMs / 1000),
       },
     });
@@ -170,8 +175,8 @@ const defaultRateLimiter = rateLimit({
   max: 100, // Limit each IP to 100 requests per windowMs
   message: {
     error: {
-      message: "Too many requests, please try again later.",
-      code: "RateLimitExceeded",
+      message: ERROR_MESSAGES[ERROR_CODES.RATE_LIMIT_EXCEEDED],
+      code: ERROR_CODES.RATE_LIMIT_EXCEEDED,
     },
   },
   store: new RedisStore({
@@ -189,8 +194,8 @@ const reportRateLimiter = rateLimit({
   max: REPORT_LIMIT_MAX,
   message: {
     error: {
-      message: "Too many requests, please try again later.",
-      code: "RateLimitExceeded",
+      message: ERROR_MESSAGES[ERROR_CODES.RATE_LIMIT_EXCEEDED],
+      code: ERROR_CODES.RATE_LIMIT_EXCEEDED,
     },
   },
   store: new RedisStore({
@@ -214,8 +219,8 @@ const authRateLimiter = rateLimit({
   max: AUTH_LIMIT_MAX,
   message: {
     error: {
-      message: "Too many requests, please try again later.",
-      code: "RateLimitExceeded",
+      message: ERROR_MESSAGES[ERROR_CODES.RATE_LIMIT_EXCEEDED],
+      code: ERROR_CODES.RATE_LIMIT_EXCEEDED,
     },
   },
   store: new RedisStore({

--- a/express-server/src/types/request.ts
+++ b/express-server/src/types/request.ts
@@ -3,10 +3,23 @@ import { Logger } from "pino";
 import { DecodedIdToken } from "firebase-admin/auth";
 
 /**
- * Extended Express Request interface that includes the pino-http logger
+ * Extended Express Request interface that includes the pino-http logger.
+ *
+ * Note: pino-http also adds a request ID as `req.id`, but we can't declare it
+ * here because it conflicts with Express's Request.id method signature.
+ * Access it via getRequestId() helper when needed.
  */
 export interface RequestWithLogger extends Request {
   log: Logger;
+}
+
+/**
+ * Get the pino-http request ID from a request.
+ * Returns undefined if pino-http middleware hasn't run.
+ */
+export function getRequestId(req: Request): string | undefined {
+  // pino-http adds id as a string property
+  return (req as unknown as { id?: string }).id;
 }
 
 /**

--- a/next-client/src/app/create/page.tsx
+++ b/next-client/src/app/create/page.tsx
@@ -1,9 +1,19 @@
 "use client";
 
+import Link from "next/link";
 import CreateReport from "@/components/create/CreateReport";
 import { useUser } from "@/lib/hooks/getUser";
 import { Center } from "@/components/layout";
-import { Spinner } from "@/components/elements";
+import { Button, Spinner } from "@/components/elements";
+import { signInWithGoogle } from "@/lib/firebase/auth";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/elements/empty";
+import { ExternalLink } from "lucide-react";
 
 export default function ReportCreationPage() {
   const { user, loading } = useUser();
@@ -19,7 +29,32 @@ export default function ReportCreationPage() {
   if (user === null) {
     return (
       <Center>
-        <p>Please login to create a report</p>
+        <Empty className="border-0 bg-background p-8 rounded-lg max-w-sm">
+          <EmptyHeader>
+            <EmptyTitle>Sign in required</EmptyTitle>
+            <EmptyDescription>
+              Please sign in to create a report.
+            </EmptyDescription>
+          </EmptyHeader>
+
+          <EmptyContent>
+            <div className="flex gap-2">
+              <Button onClick={() => signInWithGoogle()} variant="default">
+                Sign in with Google
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/">Homepage</Link>
+              </Button>
+            </div>
+
+            <Button asChild variant="link" className="text-muted-foreground">
+              <a href="mailto:hello@aiobjectives.org">
+                Email support
+                <ExternalLink className="ml-1 h-4 w-4" aria-hidden="true" />
+              </a>
+            </Button>
+          </EmptyContent>
+        </Empty>
       </Center>
     );
   }

--- a/next-client/src/app/error-test/page.tsx
+++ b/next-client/src/app/error-test/page.tsx
@@ -1,0 +1,757 @@
+"use client";
+
+/**
+ * TEMPORARY TEST PAGE - Remove after designer review
+ *
+ * This page provides links to test all error pages and states.
+ * Visit /error-test to access the test suite.
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/elements/button/Button";
+import { Col } from "@/components/layout/Directions";
+import { SubmissionErrorBanner } from "@/components/create/components/SubmissionErrorBanner";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/elements/empty";
+import { ReportErrorState } from "@/components/report/ReportErrorState";
+import { ERROR_CODES, ERROR_MESSAGES } from "tttc-common/errors";
+
+export default function ErrorTestPage() {
+  const [triggerError, setTriggerError] = useState(false);
+
+  if (triggerError) {
+    throw new Error("Test error triggered by button click");
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-8">
+      <Col gap={6}>
+        <div>
+          <h1 className="text-2xl font-semibold mb-2">Error Page Test Suite</h1>
+          <p className="text-muted-foreground">
+            Click each link/button to test the different error states and pages.
+          </p>
+        </div>
+
+        {/* Error Boundary Pages */}
+        <section>
+          <h2 className="text-lg font-medium mb-3 border-b pb-2">
+            Error Boundary Pages
+          </h2>
+          <Col gap={3}>
+            <TestItemWithPreview
+              title="App Error Page (error.tsx)"
+              description="Shows when a runtime error occurs. Error digest only appears in production builds."
+              action={
+                <Button
+                  onClick={() => setTriggerError(true)}
+                  variant="outline"
+                  size="sm"
+                >
+                  Trigger live
+                </Button>
+              }
+            >
+              <AppErrorPreview />
+            </TestItemWithPreview>
+
+            <TestItemWithPreview
+              title="Global Error Page (global-error.tsx)"
+              description="Shows when the root layout fails. Uses inline styles."
+            >
+              <GlobalErrorPreview />
+            </TestItemWithPreview>
+          </Col>
+        </section>
+
+        {/* Static Error Pages */}
+        <section>
+          <h2 className="text-lg font-medium mb-3 border-b pb-2">
+            Static Error Pages
+          </h2>
+          <Col gap={3}>
+            <TestItem
+              title="404 Not Found Page"
+              description="Shows when navigating to a URL that doesn't exist."
+            >
+              <Button asChild variant="outline">
+                <Link href="/this-page-does-not-exist-12345">
+                  Visit Non-existent Page
+                </Link>
+              </Button>
+            </TestItem>
+          </Col>
+        </section>
+
+        {/* Report Error States */}
+        <section>
+          <h2 className="text-lg font-medium mb-3 border-b pb-2">
+            Report Error States
+          </h2>
+          <Col gap={3}>
+            <TestItemWithPreview
+              title="Report Not Found"
+              description="Shows when trying to view a report that doesn't exist in the database."
+              action={
+                <Button asChild variant="outline" size="sm">
+                  <Link href="/report/INVALIDREPORTID123">Test live</Link>
+                </Button>
+              }
+            >
+              <div className="bg-background">
+                <ReportErrorState type="notFound" />
+              </div>
+            </TestItemWithPreview>
+
+            <TestItemWithPreview
+              title="Report Generation Failed"
+              description="Shows when a report failed to generate."
+            >
+              <div className="bg-background">
+                <ReportErrorState type="failed" />
+              </div>
+            </TestItemWithPreview>
+
+            <TestItemWithPreview
+              title="Report Load Error"
+              description="Shows when there's an issue loading a report."
+            >
+              <div className="bg-background">
+                <ReportErrorState type="loadError" />
+              </div>
+            </TestItemWithPreview>
+          </Col>
+        </section>
+
+        {/* All Error Codes */}
+        <section>
+          <h2 className="text-lg font-medium mb-3 border-b pb-2">
+            All Error Codes &amp; Messages
+          </h2>
+          <p className="text-sm text-muted-foreground mb-3">
+            Complete list of error codes and their user-facing messages. These
+            appear as inline banners on forms or in API responses.
+          </p>
+
+          {/* Auth Errors */}
+          <h3 className="text-md font-medium mt-4 mb-2 text-muted-foreground">
+            Authentication Errors
+          </h3>
+          <Col gap={3}>
+            <ErrorPreview code={ERROR_CODES.AUTH_TOKEN_MISSING} />
+            <ErrorPreview code={ERROR_CODES.AUTH_TOKEN_INVALID} />
+            <ErrorPreview code={ERROR_CODES.AUTH_TOKEN_EXPIRED} />
+            <ErrorPreview code={ERROR_CODES.AUTH_EMAIL_NOT_VERIFIED} />
+            <ErrorPreview code={ERROR_CODES.AUTH_UNAUTHORIZED} />
+          </Col>
+
+          {/* Validation Errors */}
+          <h3 className="text-md font-medium mt-6 mb-2 text-muted-foreground">
+            Validation Errors
+          </h3>
+          <Col gap={3}>
+            <ErrorPreview code={ERROR_CODES.VALIDATION_ERROR} />
+            <ErrorPreview code={ERROR_CODES.INVALID_REQUEST} />
+            <ErrorPreview code={ERROR_CODES.CSV_TOO_LARGE} />
+            <ErrorPreview code={ERROR_CODES.CSV_INVALID_FORMAT} />
+            <ErrorPreview code={ERROR_CODES.CSV_SECURITY_VIOLATION} />
+            <ErrorPreview code={ERROR_CODES.INVALID_REPORT_URI} />
+          </Col>
+
+          {/* Resource Errors */}
+          <h3 className="text-md font-medium mt-6 mb-2 text-muted-foreground">
+            Resource Errors
+          </h3>
+          <Col gap={3}>
+            <ErrorPreview code={ERROR_CODES.REPORT_NOT_FOUND} />
+            <ErrorPreview code={ERROR_CODES.USER_NOT_FOUND} />
+          </Col>
+
+          {/* Rate Limiting */}
+          <h3 className="text-md font-medium mt-6 mb-2 text-muted-foreground">
+            Rate Limiting
+          </h3>
+          <Col gap={3}>
+            <ErrorPreview code={ERROR_CODES.RATE_LIMIT_EXCEEDED} />
+          </Col>
+
+          {/* Server Errors */}
+          <h3 className="text-md font-medium mt-6 mb-2 text-muted-foreground">
+            Server Errors (with request ID for log correlation)
+          </h3>
+          <Col gap={3}>
+            <ErrorPreview code={ERROR_CODES.INTERNAL_ERROR} showRequestId />
+            <ErrorPreview code={ERROR_CODES.PIPELINE_FAILED} showRequestId />
+            <ErrorPreview code={ERROR_CODES.STORAGE_ERROR} showRequestId />
+            <ErrorPreview
+              code={ERROR_CODES.SERVICE_UNAVAILABLE}
+              showRequestId
+            />
+            <ErrorPreview code={ERROR_CODES.DATABASE_ERROR} showRequestId />
+          </Col>
+        </section>
+
+        {/* Sign In Required */}
+        <section>
+          <h2 className="text-lg font-medium mb-3 border-b pb-2">
+            Sign In Required Page
+          </h2>
+          <Col gap={3}>
+            <TestItemWithPreview
+              title="Sign In Required Page"
+              description="Shows when visiting /create without being logged in."
+              action={
+                <Button asChild variant="outline" size="sm">
+                  <Link href="/create">View live</Link>
+                </Button>
+              }
+            >
+              <SignInRequiredPreview />
+            </TestItemWithPreview>
+          </Col>
+        </section>
+
+        {/* Design Notes */}
+        <section className="bg-muted/50 rounded-lg p-4">
+          <h2 className="text-lg font-medium mb-2">Design Review Notes</h2>
+          <ul className="text-sm text-muted-foreground space-y-1 list-disc list-inside">
+            <li>
+              Error reference code should be easy to copy (click the Copy
+              button)
+            </li>
+            <li>
+              Email support link should pre-fill subject and body with error
+              reference
+            </li>
+            <li>
+              All error pages should be centered vertically and horizontally
+            </li>
+            <li>
+              Global error page uses inline styles (test visually matches app
+              error page)
+            </li>
+            <li>Inline form errors use red destructive color scheme</li>
+          </ul>
+        </section>
+      </Col>
+    </div>
+  );
+}
+
+function TestItem({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 p-3 border rounded-lg">
+      <div>
+        <h3 className="font-medium">{title}</h3>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="flex-shrink-0">{children}</div>
+    </div>
+  );
+}
+
+function TestItemWithPreview({
+  title,
+  description,
+  action,
+  children,
+}: {
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <div className="flex items-start justify-between gap-4 p-3 bg-muted/50">
+        <div>
+          <h3 className="font-medium">{title}</h3>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+        {action && <div className="flex-shrink-0">{action}</div>}
+      </div>
+      <div className="border-t">{children}</div>
+    </div>
+  );
+}
+
+function ErrorPreview({
+  code,
+  showRequestId = false,
+}: {
+  code: string;
+  showRequestId?: boolean;
+}) {
+  const message = ERROR_MESSAGES[code as keyof typeof ERROR_MESSAGES];
+  // Generate a mock request ID for server errors to show what it looks like
+  const mockRequestId = showRequestId ? "req-a1b2c3d4e5f6" : undefined;
+
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <div className="flex items-center gap-2 p-2 bg-muted/50 border-b">
+        <code className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded">
+          {code}
+        </code>
+        {showRequestId && (
+          <span className="text-xs text-muted-foreground">
+            (with request ID)
+          </span>
+        )}
+      </div>
+      <div className="p-3 bg-background">
+        <SubmissionErrorBanner
+          error={{ code, message, requestId: mockRequestId }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Preview of the app error page using actual components with mock digest.
+ * This mirrors error.tsx to show what it looks like with a digest.
+ */
+function AppErrorPreview() {
+  const [copied, setCopied] = useState(false);
+  const mockDigest = "abc123def456";
+
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(mockDigest);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const supportEmailHref = `mailto:hello@aiobjectives.org?subject=${encodeURIComponent(`Error report: ${mockDigest}`)}&body=${encodeURIComponent(`Hi,\n\nI encountered an error while using Talk to the City.\n\nError reference: ${mockDigest}\n\nWhat I was doing when this happened:\n[Please describe what you were trying to do]\n\nThanks`)}`;
+
+  return (
+    <div className="flex min-h-[300px] w-full items-center justify-center bg-background p-8">
+      <Empty className="border-0 bg-background p-8 rounded-lg max-w-sm">
+        <EmptyHeader>
+          <EmptyTitle>Something went wrong</EmptyTitle>
+          <EmptyDescription>
+            We encountered an unexpected error. This has been logged and
+            we&apos;ll look into it.
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <div className="flex gap-2">
+            <Button onClick={(e) => e.preventDefault()} variant="default">
+              Try again
+            </Button>
+            <Button variant="outline" onClick={(e) => e.preventDefault()}>
+              Homepage
+            </Button>
+          </div>
+
+          <Button
+            asChild
+            variant="link"
+            className="text-muted-foreground"
+            onClick={(e) => e.preventDefault()}
+          >
+            <a href={supportEmailHref}>
+              Email support
+              <svg
+                className="ml-1 h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </a>
+          </Button>
+        </EmptyContent>
+
+        <div className="w-full rounded-lg border bg-muted/50 p-4 text-left">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-foreground">
+                Error reference
+              </span>
+              <button
+                onClick={copyToClipboard}
+                aria-label="Copy error reference"
+                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {copied ? (
+                  <>
+                    <svg
+                      className="h-3 w-3"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      aria-hidden="true"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <svg
+                      className="h-3 w-3"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      aria-hidden="true"
+                    >
+                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                    </svg>
+                    Copy
+                  </>
+                )}
+              </button>
+            </div>
+            <code className="text-sm font-mono text-muted-foreground">
+              {mockDigest}
+            </code>
+            <p className="text-xs text-muted-foreground">
+              Include this code when contacting support
+            </p>
+          </div>
+        </div>
+      </Empty>
+    </div>
+  );
+}
+
+/**
+ * Preview of the global error page using the same inline styles.
+ * This mirrors global-error.tsx but without the html/body wrapper.
+ */
+function GlobalErrorPreview() {
+  const [copied, setCopied] = useState(false);
+  const mockDigest = "abc123def456";
+
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(mockDigest);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const supportEmailHref = `mailto:hello@aiobjectives.org?subject=${encodeURIComponent(`Error report: ${mockDigest}`)}&body=${encodeURIComponent(`Hi,\n\nI encountered an error while using Talk to the City.\n\nError reference: ${mockDigest}\n\nWhat I was doing when this happened:\n[Please describe what you were trying to do]\n\nThanks`)}`;
+
+  return (
+    <div
+      style={{
+        fontFamily:
+          'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        backgroundColor: "#ffffff",
+        color: "#0f172a",
+        padding: "48px 24px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: "384px",
+          padding: "32px",
+          textAlign: "center",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "24px",
+        }}
+      >
+        {/* Header section */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "8px",
+            maxWidth: "384px",
+          }}
+        >
+          <h1
+            style={{
+              fontSize: "16px",
+              fontWeight: 500,
+              lineHeight: "24px",
+              margin: 0,
+            }}
+          >
+            Something went wrong
+          </h1>
+          <p
+            style={{
+              fontSize: "14px",
+              lineHeight: "20px",
+              color: "#64748b",
+              margin: 0,
+            }}
+          >
+            We encountered an unexpected error. This has been logged and
+            we&apos;ll look into it.
+          </p>
+        </div>
+
+        {/* Content section */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "16px",
+            width: "100%",
+            maxWidth: "384px",
+          }}
+        >
+          {/* Horizontal button group */}
+          <div
+            style={{
+              display: "flex",
+              gap: "8px",
+            }}
+          >
+            <button
+              style={{
+                backgroundColor: "hsl(243, 75%, 59%)",
+                color: "#ffffff",
+                border: "none",
+                borderRadius: "6px",
+                padding: "8px 16px",
+                fontSize: "14px",
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+            <a
+              href="/"
+              onClick={(e) => e.preventDefault()}
+              style={{
+                backgroundColor: "transparent",
+                color: "#0f172a",
+                border: "1px solid #e2e8f0",
+                borderRadius: "6px",
+                padding: "8px 16px",
+                fontSize: "14px",
+                fontWeight: 500,
+                textDecoration: "none",
+                display: "inline-flex",
+                alignItems: "center",
+              }}
+            >
+              Homepage
+            </a>
+          </div>
+
+          {/* Email support link */}
+          <a
+            href={supportEmailHref}
+            onClick={(e) => e.preventDefault()}
+            style={{
+              fontSize: "14px",
+              color: "#64748b",
+              textDecoration: "none",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "4px",
+            }}
+          >
+            Email support
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+          </a>
+        </div>
+
+        {/* Error reference box */}
+        <div
+          style={{
+            backgroundColor: "#f8fafc",
+            border: "1px solid #e2e8f0",
+            borderRadius: "8px",
+            padding: "16px",
+            textAlign: "left",
+            width: "100%",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "8px",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
+            >
+              <span
+                style={{
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  color: "#0f172a",
+                }}
+              >
+                Error reference
+              </span>
+              <button
+                onClick={copyToClipboard}
+                style={{
+                  background: "none",
+                  border: "none",
+                  fontSize: "12px",
+                  color: "#64748b",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "4px",
+                }}
+              >
+                {copied ? (
+                  <>
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                    </svg>
+                    Copy
+                  </>
+                )}
+              </button>
+            </div>
+            <code
+              style={{
+                fontSize: "14px",
+                fontFamily: "monospace",
+                color: "#64748b",
+              }}
+            >
+              {mockDigest}
+            </code>
+            <p
+              style={{
+                fontSize: "12px",
+                color: "#64748b",
+                marginTop: "0",
+                marginBottom: 0,
+              }}
+            >
+              Include this code when contacting support
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Preview of the sign-in required page using actual components.
+ */
+function SignInRequiredPreview() {
+  return (
+    <div className="flex min-h-[300px] w-full items-center justify-center bg-background p-8">
+      <Empty className="border-0 bg-background p-8 rounded-lg max-w-sm">
+        <EmptyHeader>
+          <EmptyTitle>Sign in required</EmptyTitle>
+          <EmptyDescription>
+            Please sign in to create a report.
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <div className="flex gap-2">
+            <Button onClick={(e) => e.preventDefault()} variant="default">
+              Sign in with Google
+            </Button>
+            <Button variant="outline" onClick={(e) => e.preventDefault()}>
+              Homepage
+            </Button>
+          </div>
+
+          <Button
+            asChild
+            variant="link"
+            className="text-muted-foreground"
+            onClick={(e) => e.preventDefault()}
+          >
+            <a href="mailto:hello@aiobjectives.org">
+              Email support
+              <svg
+                className="ml-1 h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </a>
+          </Button>
+        </EmptyContent>
+      </Empty>
+    </div>
+  );
+}

--- a/next-client/src/app/error.tsx
+++ b/next-client/src/app/error.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/elements/button/Button";
+import { Center } from "@/components/layout/Center";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/elements/empty";
+import { Copy, Check, ExternalLink } from "lucide-react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    // Log error digest for debugging (safe to expose - no sensitive data)
+    console.error("Application error:", {
+      message: error.message,
+      digest: error.digest,
+    });
+  }, [error]);
+
+  const copyToClipboard = async () => {
+    if (error.digest) {
+      await navigator.clipboard.writeText(error.digest);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const supportEmailHref = error.digest
+    ? `mailto:hello@aiobjectives.org?subject=${encodeURIComponent(`Error report: ${error.digest}`)}&body=${encodeURIComponent(`Hi,\n\nI encountered an error while using Talk to the City.\n\nError reference: ${error.digest}\n\nWhat I was doing when this happened:\n[Please describe what you were trying to do]\n\nThanks`)}`
+    : "mailto:hello@aiobjectives.org";
+
+  return (
+    <Center>
+      <Empty className="border-0 bg-background p-8 rounded-lg max-w-sm">
+        <EmptyHeader>
+          <EmptyTitle>Something went wrong</EmptyTitle>
+          <EmptyDescription>
+            We encountered an unexpected error. This has been logged and we'll
+            look into it.
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <div className="flex gap-2">
+            <Button onClick={reset} variant="default">
+              Try again
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/">Homepage</Link>
+            </Button>
+          </div>
+
+          <Button asChild variant="link" className="text-muted-foreground">
+            <a href={supportEmailHref}>
+              Email support
+              <ExternalLink className="ml-1 h-4 w-4" aria-hidden="true" />
+            </a>
+          </Button>
+        </EmptyContent>
+
+        {error.digest && (
+          <div className="w-full rounded-lg border bg-muted/50 p-4 text-left">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-foreground">
+                  Error reference
+                </span>
+                <button
+                  onClick={copyToClipboard}
+                  aria-label="Copy error reference"
+                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="h-3 w-3" aria-hidden="true" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-3 w-3" aria-hidden="true" />
+                      Copy
+                    </>
+                  )}
+                </button>
+                {copied && (
+                  <span className="sr-only">
+                    Error reference copied to clipboard
+                  </span>
+                )}
+              </div>
+              <code className="text-sm font-mono text-muted-foreground">
+                {error.digest}
+              </code>
+              <p className="text-xs text-muted-foreground">
+                Include this code when contacting support
+              </p>
+            </div>
+          </div>
+        )}
+      </Empty>
+    </Center>
+  );
+}

--- a/next-client/src/app/global-error.tsx
+++ b/next-client/src/app/global-error.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Global error boundary for root layout errors.
+ * This is a fallback when the root layout itself fails to render.
+ * Must include own html/body tags since the root layout may have errored.
+ * Uses inline styles since CSS files may not be available.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    console.error("Global error:", {
+      message: error.message,
+      digest: error.digest,
+    });
+  }, [error]);
+
+  const copyToClipboard = async () => {
+    if (error.digest) {
+      await navigator.clipboard.writeText(error.digest);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const supportEmailHref = error.digest
+    ? `mailto:hello@aiobjectives.org?subject=${encodeURIComponent(`Error report: ${error.digest}`)}&body=${encodeURIComponent(`Hi,\n\nI encountered an error while using Talk to the City.\n\nError reference: ${error.digest}\n\nWhat I was doing when this happened:\n[Please describe what you were trying to do]\n\nThanks`)}`
+    : "mailto:hello@aiobjectives.org";
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          fontFamily:
+            'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          backgroundColor: "#ffffff",
+          color: "#0f172a",
+          margin: 0,
+          padding: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <div
+          style={{
+            maxWidth: "384px",
+            padding: "32px",
+            textAlign: "center",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "24px",
+          }}
+        >
+          {/* Header section */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "8px",
+              maxWidth: "384px",
+            }}
+          >
+            <h1
+              style={{
+                fontSize: "16px",
+                fontWeight: 500,
+                lineHeight: "24px",
+                margin: 0,
+              }}
+            >
+              Something went wrong
+            </h1>
+            <p
+              style={{
+                fontSize: "14px",
+                lineHeight: "20px",
+                color: "#64748b",
+                margin: 0,
+              }}
+            >
+              We encountered an unexpected error. This has been logged and
+              we&apos;ll look into it.
+            </p>
+          </div>
+
+          {/* Content section */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "16px",
+              width: "100%",
+              maxWidth: "384px",
+            }}
+          >
+            {/* Horizontal button group */}
+            <div
+              style={{
+                display: "flex",
+                gap: "8px",
+              }}
+            >
+              <button
+                onClick={reset}
+                style={{
+                  backgroundColor: "hsl(243, 75%, 59%)",
+                  color: "#ffffff",
+                  border: "none",
+                  borderRadius: "6px",
+                  padding: "8px 16px",
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  cursor: "pointer",
+                }}
+              >
+                Try again
+              </button>
+              <a
+                href="/"
+                style={{
+                  backgroundColor: "transparent",
+                  color: "#0f172a",
+                  border: "1px solid #e2e8f0",
+                  borderRadius: "6px",
+                  padding: "8px 16px",
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  textDecoration: "none",
+                  display: "inline-flex",
+                  alignItems: "center",
+                }}
+              >
+                Homepage
+              </a>
+            </div>
+
+            {/* Email support link */}
+            <a
+              href={supportEmailHref}
+              style={{
+                fontSize: "14px",
+                color: "#64748b",
+                textDecoration: "none",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "4px",
+              }}
+            >
+              Email support
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+            </a>
+          </div>
+
+          {/* Error reference box */}
+          {error.digest && (
+            <div
+              style={{
+                backgroundColor: "#f8fafc",
+                border: "1px solid #e2e8f0",
+                borderRadius: "8px",
+                padding: "16px",
+                textAlign: "left",
+                width: "100%",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "8px",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: "14px",
+                      fontWeight: 500,
+                      color: "#0f172a",
+                    }}
+                  >
+                    Error reference
+                  </span>
+                  <button
+                    onClick={copyToClipboard}
+                    aria-label="Copy error reference"
+                    style={{
+                      background: "none",
+                      border: "none",
+                      fontSize: "12px",
+                      color: "#64748b",
+                      cursor: "pointer",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "4px",
+                    }}
+                  >
+                    {copied ? (
+                      <>
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          aria-hidden="true"
+                        >
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                        Copied
+                      </>
+                    ) : (
+                      <>
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          aria-hidden="true"
+                        >
+                          <rect
+                            x="9"
+                            y="9"
+                            width="13"
+                            height="13"
+                            rx="2"
+                            ry="2"
+                          />
+                          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                        </svg>
+                        Copy
+                      </>
+                    )}
+                  </button>
+                  {copied && (
+                    <span
+                      style={{
+                        position: "absolute",
+                        width: "1px",
+                        height: "1px",
+                        padding: 0,
+                        margin: "-1px",
+                        overflow: "hidden",
+                        clip: "rect(0, 0, 0, 0)",
+                        whiteSpace: "nowrap",
+                        border: 0,
+                      }}
+                    >
+                      Error reference copied to clipboard
+                    </span>
+                  )}
+                </div>
+                <code
+                  style={{
+                    fontSize: "14px",
+                    fontFamily: "monospace",
+                    color: "#64748b",
+                  }}
+                >
+                  {error.digest}
+                </code>
+                <p
+                  style={{
+                    fontSize: "12px",
+                    color: "#64748b",
+                    marginTop: "0",
+                    marginBottom: 0,
+                  }}
+                >
+                  Include this code when contacting support
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/next-client/src/app/not-found.tsx
+++ b/next-client/src/app/not-found.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { Button } from "@/components/elements/button/Button";
+import { Center } from "@/components/layout/Center";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/elements/empty";
+
+export default function NotFound() {
+  return (
+    <Center>
+      <Empty className="border-0 bg-background p-8 rounded-lg max-w-sm">
+        <EmptyHeader>
+          <EmptyTitle>Page not found</EmptyTitle>
+          <EmptyDescription>
+            The page you're looking for doesn't exist or may have been moved.
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <Button asChild variant="outline">
+            <Link href="/">Homepage</Link>
+          </Button>
+        </EmptyContent>
+      </Empty>
+    </Center>
+  );
+}

--- a/next-client/src/app/report/[uri]/error.tsx
+++ b/next-client/src/app/report/[uri]/error.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/elements/button/Button";
+import { Center } from "@/components/layout/Center";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/elements/empty";
+import { ExternalLink } from "lucide-react";
+
+export default function ReportError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Report error:", {
+      message: error.message,
+      digest: error.digest,
+    });
+  }, [error]);
+
+  const supportEmailHref = error.digest
+    ? `mailto:hello@aiobjectives.org?subject=${encodeURIComponent(`Report error: ${error.digest}`)}&body=${encodeURIComponent(`Hi,\n\nI encountered an error loading a report.\n\nError reference: ${error.digest}\n\nReport URL: ${typeof window !== "undefined" ? window.location.href : ""}\n\nThanks`)}`
+    : "mailto:hello@aiobjectives.org";
+
+  return (
+    <Center>
+      <Empty className="border-0 bg-background p-8 rounded-lg max-w-sm">
+        <EmptyHeader>
+          <EmptyTitle>Unable to load report</EmptyTitle>
+          <EmptyDescription>
+            We couldn't load this report. It may still be generating, or there
+            might be a temporary issue with our service.
+          </EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <div className="flex gap-2">
+            <Button onClick={reset} variant="default">
+              Try again
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/my-reports">My reports</Link>
+            </Button>
+          </div>
+
+          <Button asChild variant="link" className="text-muted-foreground">
+            <a href={supportEmailHref}>
+              Email support
+              <ExternalLink className="ml-1 h-4 w-4" aria-hidden="true" />
+            </a>
+          </Button>
+
+          {error.digest && (
+            <span className="font-mono text-xs text-muted-foreground">
+              ref: {error.digest}
+            </span>
+          )}
+        </EmptyContent>
+      </Empty>
+    </Center>
+  );
+}

--- a/next-client/src/app/report/[uri]/page.tsx
+++ b/next-client/src/app/report/[uri]/page.tsx
@@ -3,6 +3,7 @@ import * as schema from "tttc-common/schema";
 import * as api from "tttc-common/api";
 import * as utils from "tttc-common/utils";
 import ReportProgress from "@/components/reportProgress/ReportProgress";
+import { ReportErrorState } from "@/components/report/ReportErrorState";
 import Feedback from "@/components/feedback/Feedback";
 import pRetry from "p-retry";
 import { logger } from "tttc-common/logger/browser";
@@ -159,11 +160,11 @@ async function ReportPageContent({ encodedUri }: { encodedUri: string }) {
 
   switch (state.type) {
     case "notFound":
-      return <ReportProgress status="notFound" />;
+      return <ReportErrorState type="notFound" />;
     case "progress":
       return <ReportProgress status={state.status} identifier={encodedUri} />;
     case "error":
-      return <p>{state.message}</p>;
+      return <ReportErrorState type="loadError" message={state.message} />;
     case "reportData":
       return (
         <div>
@@ -176,7 +177,7 @@ async function ReportPageContent({ encodedUri }: { encodedUri: string }) {
         </div>
       );
     case "reportDataError":
-      return <p>{state.message}</p>;
+      return <ReportErrorState type="loadError" message={state.message} />;
     default:
       utils.assertNever(state);
   }

--- a/next-client/src/components/create/components/SubmissionErrorBanner.tsx
+++ b/next-client/src/components/create/components/SubmissionErrorBanner.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { AlertCircle, Copy, Check, ExternalLink } from "lucide-react";
+import type { FormActionError } from "tttc-common/api";
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  Button,
+} from "@/components/elements";
+
+interface SubmissionErrorBannerProps {
+  error: FormActionError;
+}
+
+// Server-side error codes where user can't fix the problem and may need to contact support
+const SERVER_ERROR_CODES = [
+  "INTERNAL_ERROR",
+  "PIPELINE_FAILED",
+  "STORAGE_ERROR",
+  "SERVICE_UNAVAILABLE",
+  "DATABASE_ERROR",
+];
+
+function isServerError(code: string): boolean {
+  return SERVER_ERROR_CODES.includes(code);
+}
+
+export function SubmissionErrorBanner({ error }: SubmissionErrorBannerProps) {
+  const [copied, setCopied] = useState(false);
+  const showErrorReference = isServerError(error.code);
+
+  // Use requestId if available, otherwise fall back to error code
+  const errorReference = error.requestId || error.code;
+
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(errorReference);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const supportEmailHref = `mailto:hello@aiobjectives.org?subject=${encodeURIComponent(`Error report: ${errorReference}`)}&body=${encodeURIComponent(`Hi,\n\nI encountered an error while using Talk to the City.\n\nError code: ${error.code}${error.requestId ? `\nRequest ID: ${error.requestId}` : ""}\nError message: ${error.message}\n\nWhat I was doing when this happened:\n[Please describe what you were trying to do]\n\nThanks`)}`;
+
+  return (
+    <Alert variant="destructive" aria-live="assertive">
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>Unable to create report</AlertTitle>
+      <AlertDescription>{error.message}</AlertDescription>
+
+      {showErrorReference && (
+        <div className="mt-3 border-t border-destructive/20 pt-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-muted-foreground">
+              Error reference:
+            </span>
+            <code className="text-xs font-mono text-muted-foreground">
+              {errorReference}
+            </code>
+            <button
+              onClick={copyToClipboard}
+              aria-label="Copy error reference"
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors min-h-[44px] px-2 -my-2"
+            >
+              {copied ? (
+                <>
+                  <Check className="h-3 w-3" aria-hidden="true" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="h-3 w-3" aria-hidden="true" />
+                  Copy
+                </>
+              )}
+            </button>
+            {copied && (
+              <span className="sr-only">
+                Error reference copied to clipboard
+              </span>
+            )}
+          </div>
+          <Button
+            asChild
+            variant="link"
+            className="text-muted-foreground h-auto p-0 mt-2"
+          >
+            <a href={supportEmailHref}>
+              Email support
+              <ExternalLink className="ml-1 h-3 w-3" aria-hidden="true" />
+            </a>
+          </Button>
+        </div>
+      )}
+    </Alert>
+  );
+}

--- a/next-client/src/components/elements/alert.tsx
+++ b/next-client/src/components/elements/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils/shadcn";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };

--- a/next-client/src/components/elements/empty.tsx
+++ b/next-client/src/components/elements/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils/shadcn";
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-base font-medium leading-6", className)}
+      {...props}
+    />
+  );
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full min-w-0 max-w-sm flex-col items-center gap-4 text-balance text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+};

--- a/next-client/src/components/elements/index.ts
+++ b/next-client/src/components/elements/index.ts
@@ -19,4 +19,5 @@ export * from "./scrollarea/ScrollArea";
 export * from "./sheet/Sheet";
 export * from "./switch/Switch";
 export * from "./alertDialog/AlertDialog";
+export * from "./alert";
 export * from "./ErrorBoundary";

--- a/next-client/src/components/layout/Center.tsx
+++ b/next-client/src/components/layout/Center.tsx
@@ -3,13 +3,15 @@ import React from "react";
 /**
  * Centers content both horizontally and vertically.
  *
- * Uses flexbox for reliable cross-browser centering (particularly Firefox).
- * Works with both inline content (text) and block-level elements (SVGs, divs).
+ * Handles all centering concerns internally, including text alignment
+ * for cross-browser compatibility (particularly Firefox). Uses flexbox
+ * with min-height for reliable centering even when parent height context
+ * is not explicitly set.
  */
 export function Center({ children }: React.PropsWithChildren) {
   return (
-    <div className="w-full h-full flex items-center justify-center">
-      {children}
+    <div className="flex min-h-[calc(100vh-4rem)] w-full items-center justify-center">
+      <div className="text-center">{children}</div>
     </div>
   );
 }

--- a/next-client/src/components/report/ReportErrorState.tsx
+++ b/next-client/src/components/report/ReportErrorState.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { Button } from "@/components/elements/button/Button";
+import { Center } from "@/components/layout/Center";
+import {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+} from "@/components/elements/empty";
+import { ExternalLink } from "lucide-react";
+
+type ReportErrorType = "notFound" | "failed" | "loadError";
+
+interface ReportErrorStateProps {
+  type: ReportErrorType;
+  message?: string;
+}
+
+const errorConfig: Record<
+  ReportErrorType,
+  { title: string; description: string }
+> = {
+  notFound: {
+    title: "Report not found",
+    description:
+      "We couldn't find a report at this address. It may have been moved or deleted.",
+  },
+  failed: {
+    title: "Report generation failed",
+    description:
+      "Something went wrong while generating this report. Please try creating it again.",
+  },
+  loadError: {
+    title: "Unable to load report",
+    description:
+      "We couldn't load this report. There might be a temporary issue with our service.",
+  },
+};
+
+export function ReportErrorState({ type, message }: ReportErrorStateProps) {
+  const config = errorConfig[type];
+
+  return (
+    <Center>
+      <Empty
+        role="alert"
+        className="border-0 bg-background p-8 rounded-lg max-w-sm"
+      >
+        <EmptyHeader>
+          <EmptyTitle>{config.title}</EmptyTitle>
+          <EmptyDescription>{message || config.description}</EmptyDescription>
+        </EmptyHeader>
+
+        <EmptyContent>
+          <div className="flex gap-2">
+            <Button asChild variant="default">
+              <Link href="/my-reports">My reports</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/create">Create new</Link>
+            </Button>
+          </div>
+
+          <Button asChild variant="link" className="text-muted-foreground">
+            <a href="mailto:hello@aiobjectives.org">
+              Email support
+              <ExternalLink className="ml-1 h-4 w-4" aria-hidden="true" />
+            </a>
+          </Button>
+        </EmptyContent>
+      </Empty>
+    </Center>
+  );
+}

--- a/next-client/src/components/reportProgress/ReportProgress.tsx
+++ b/next-client/src/components/reportProgress/ReportProgress.tsx
@@ -6,6 +6,7 @@ import { logger } from "tttc-common/logger/browser";
 import { Col } from "../layout";
 import { Progress } from "../elements";
 import { useUnifiedReport } from "@/hooks/useUnifiedReport";
+import { ReportErrorState } from "@/components/report/ReportErrorState";
 
 const reportProgressLogger = logger.child({ module: "report-progress" });
 
@@ -50,28 +51,16 @@ export default function ReportProgress({
 const StatusDisplay = ({ status }: { status: api.ReportJobStatus }) => {
   switch (status) {
     case "failed":
-      return <JobFailed />;
+      return <ReportErrorState type="failed" />;
     case "finished":
-      return <JobFinished />;
+      // Report finished but data not found - likely moved or deleted
+      return <ReportErrorState type="notFound" />;
     case "notFound":
-      return <JobNotFound />;
+      return <ReportErrorState type="notFound" />;
     default:
       return <ReportProcessing status={status} />;
   }
 };
-
-const JobFailed = (_: unknown) => <p>Your report failed</p>;
-
-const JobFinished = (_: unknown) => (
-  <p>
-    Report finished but data not found - likely that resource was moved or
-    deleted
-  </p>
-);
-
-const JobNotFound = (_: unknown) => (
-  <p>Could not find a valid report with that uri</p>
-);
 
 function ReportProcessing({ status }: { status: api.ReportJobStatus }) {
   return (

--- a/next-client/src/features/submission/actions/SubmitAction.ts
+++ b/next-client/src/features/submission/actions/SubmitAction.ts
@@ -6,12 +6,53 @@ import {
   llmUserConfig,
 } from "tttc-common/schema";
 import Papa from "papaparse";
-import { GenerateApiResponse, GenerateApiRequest } from "tttc-common/api";
+import { GenerateApiRequest, CreateReportActionResult } from "tttc-common/api";
+import { ERROR_CODES, ERROR_MESSAGES } from "tttc-common/errors";
 import { validatedServerEnv } from "@/server-env";
 import { logger } from "tttc-common/logger/browser";
 import { formatData } from "tttc-common/csv-validation";
+import { serverSideAnalyticsClient } from "@/lib/analytics/serverSideAnalytics";
+import { CommonEvents } from "tttc-common/analytics";
 
 const submitActionLogger = logger.child({ module: "submit-action" });
+
+/**
+ * Categorize error codes for analytics grouping
+ */
+function categorizeError(
+  code: string,
+): "auth" | "validation" | "server" | "rate_limit" {
+  if (code.startsWith("AUTH_")) return "auth";
+  if (
+    code.startsWith("CSV_") ||
+    code.startsWith("VALIDATION_") ||
+    code.startsWith("INVALID_")
+  )
+    return "validation";
+  if (code === "RATE_LIMIT_EXCEEDED") return "rate_limit";
+  return "server";
+}
+
+/**
+ * Track form submission errors for analytics
+ */
+async function trackFormError(code: string, requestId?: string): Promise<void> {
+  try {
+    const analytics = await serverSideAnalyticsClient();
+    await analytics.track({
+      name: CommonEvents.ERROR_OCCURRED,
+      properties: {
+        error_code: code,
+        error_category: categorizeError(code),
+        has_request_id: Boolean(requestId),
+        form: "create_report",
+      },
+    });
+  } catch (error) {
+    // Don't let analytics failures affect the user flow
+    submitActionLogger.warn({ error }, "Failed to track form error");
+  }
+}
 
 const parseCSV = async (file: File): Promise<SourceRow[]> => {
   const buffer = await file.arrayBuffer();
@@ -27,64 +68,106 @@ const parseCSV = async (file: File): Promise<SourceRow[]> => {
 export default async function submitAction(
   firebaseAuthToken: string | null,
   formData: FormData,
-): Promise<GenerateApiResponse> {
+): Promise<CreateReportActionResult> {
+  // Return error for missing auth instead of throwing
   if (!firebaseAuthToken) {
-    throw new Error("You need to be logged in to create a report.");
-  }
-  // parses csv file
-  // TODO: redact/overwrite API key, other fields are fine to log
-  // console.log("starting to parse", formData);
-  // if csv file is empty, return error
-  const file = formData.get("dataInput") as File;
-  const data = await parseCSV(file);
-  if (!data || !data.length) {
-    throw new Error("Missing data. Check your csv file");
+    await trackFormError(ERROR_CODES.AUTH_TOKEN_MISSING);
+    return {
+      status: "error",
+      error: {
+        code: ERROR_CODES.AUTH_TOKEN_MISSING,
+        message: ERROR_MESSAGES.AUTH_TOKEN_MISSING,
+      },
+    };
   }
 
-  const config: LLMUserConfig = llmUserConfig.parse({
-    title: formData.get("title"),
-    // question: formData.get("question"),
-    description: formData.get("description"),
-    clusteringInstructions: formData.get("clusteringInstructions"),
-    systemInstructions: formData.get("systemInstructions"),
-    extractionInstructions: formData.get("extractionInstructions"),
-    dedupInstructions: formData.get("dedupInstructions"),
-    summariesInstructions: formData.get("summariesInstructions"),
-    cruxInstructions: formData.get("cruxInstructions"),
-    // Checkbox inputs use 'on' | undefined, not true | false
-    cruxesEnabled: formData.get("cruxesEnabled") === "on",
-    bridgingEnabled: formData.get("bridgingEnabled") === "on",
-  });
-  const dataPayload: DataPayload = ["csv", data];
-  submitActionLogger.debug(
-    { cruxesEnabled: config.cruxesEnabled },
-    "Submit action crux config",
-  );
-  const body: GenerateApiRequest = {
-    userConfig: config,
-    data: dataPayload,
-    firebaseAuthToken,
-  };
-  submitActionLogger.debug(
-    { cruxesEnabled: body.userConfig.cruxesEnabled },
-    "Submit action body config",
-  );
-  const url = new URL("create", validatedServerEnv.PIPELINE_EXPRESS_URL);
+  try {
+    // Parse CSV file
+    const file = formData.get("dataInput") as File;
+    const data = await parseCSV(file);
 
-  const response = await fetch(url, {
-    method: "POST",
-    body: JSON.stringify(body),
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-  if (!response.ok) {
-    const errorData = await response.json();
-    throw new Error(
-      errorData.error?.message ||
-        errorData.error ||
-        "An unknown error occurred",
+    // Return error for empty CSV instead of throwing
+    if (!data || !data.length) {
+      await trackFormError(ERROR_CODES.CSV_INVALID_FORMAT);
+      return {
+        status: "error",
+        error: {
+          code: ERROR_CODES.CSV_INVALID_FORMAT,
+          message:
+            "The CSV file appears to be empty. Please check your file and try again.",
+        },
+      };
+    }
+
+    const config: LLMUserConfig = llmUserConfig.parse({
+      title: formData.get("title"),
+      description: formData.get("description"),
+      clusteringInstructions: formData.get("clusteringInstructions"),
+      systemInstructions: formData.get("systemInstructions"),
+      extractionInstructions: formData.get("extractionInstructions"),
+      dedupInstructions: formData.get("dedupInstructions"),
+      summariesInstructions: formData.get("summariesInstructions"),
+      cruxInstructions: formData.get("cruxInstructions"),
+      // Checkbox inputs use 'on' | undefined, not true | false
+      cruxesEnabled: formData.get("cruxesEnabled") === "on",
+      bridgingEnabled: formData.get("bridgingEnabled") === "on",
+    });
+
+    const dataPayload: DataPayload = ["csv", data];
+    submitActionLogger.debug(
+      { cruxesEnabled: config.cruxesEnabled },
+      "Submit action crux config",
     );
+
+    const body: GenerateApiRequest = {
+      userConfig: config,
+      data: dataPayload,
+      firebaseAuthToken,
+    };
+    submitActionLogger.debug(
+      { cruxesEnabled: body.userConfig.cruxesEnabled },
+      "Submit action body config",
+    );
+
+    const url = new URL("create", validatedServerEnv.PIPELINE_EXPRESS_URL);
+
+    const response = await fetch(url, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorCode = errorData.error?.code || ERROR_CODES.INTERNAL_ERROR;
+      const requestId = errorData.error?.requestId;
+      await trackFormError(errorCode, requestId);
+      return {
+        status: "error",
+        error: {
+          code: errorCode,
+          message: errorData.error?.message || ERROR_MESSAGES.INTERNAL_ERROR,
+          requestId,
+        },
+      };
+    }
+
+    const responseData = await response.json();
+    return { status: "success", data: responseData };
+  } catch (error) {
+    submitActionLogger.error({ error }, "Submit action failed");
+    await trackFormError(ERROR_CODES.INTERNAL_ERROR);
+    return {
+      status: "error",
+      error: {
+        code: ERROR_CODES.INTERNAL_ERROR,
+        message:
+          error instanceof Error
+            ? error.message
+            : ERROR_MESSAGES.INTERNAL_ERROR,
+      },
+    };
   }
-  return await response.json();
 }


### PR DESCRIPTION
**1. What is the goal of this PR?**

Add custom error boundary pages and shared error utilities to improve user experience when errors occur.

- Add global error.tsx and global-error.tsx for app-level errors
- Add not-found.tsx for 404 pages
- Add report-specific error.tsx for report loading failures
- Add shared error utilities in common/errors and next-client/lib/errors

**2. What specific parts of T3C are you changing and how?**

next-client, express-server, common

**3. How did you test these changes?**

Locally

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
