### PR TITLE
T3C-865: Fix email verification error handling and token refresh

### DIFF
--- a/express-server/src/routes/__tests__/create.email-verification.test.ts
+++ b/express-server/src/routes/__tests__/create.email-verification.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for email verification error handling in the create route
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import create from "../create";
+import {
+  validateParsedData,
+  detectCSVInjection,
+} from "tttc-common/csv-security";
+import * as firebase from "../../Firebase";
+
+vi.mock("tttc-common/csv-security", () => ({
+  validateParsedData: vi.fn(),
+  detectCSVInjection: vi.fn(),
+}));
+
+vi.mock("../../Firebase", () => ({
+  verifyUser: vi.fn(),
+  ensureUserDocument: vi.fn().mockResolvedValue(undefined),
+  addReportJob: vi.fn().mockResolvedValue("job-id-123"),
+  addReportRef: vi.fn().mockResolvedValue("job-id-123"),
+  createReportJobAndRef: vi.fn().mockResolvedValue({
+    jobId: "job-id-123",
+    reportId: "report-id-123",
+  }),
+  updateReportJobDataUri: vi.fn().mockResolvedValue(undefined),
+  updateReportRefDataUri: vi.fn().mockResolvedValue(undefined),
+  db: {
+    collection: vi.fn(() => ({
+      doc: vi.fn(() => ({
+        id: "test-report-id",
+        get: vi.fn(),
+        set: vi.fn(),
+        update: vi.fn(),
+      })),
+    })),
+  },
+  getCollectionName: vi.fn((collection) => `test-${collection.toLowerCase()}`),
+  admin: {
+    firestore: vi.fn(),
+  },
+}));
+
+vi.mock("../../storage", () => ({
+  createStorage: vi.fn().mockReturnValue({
+    save: vi
+      .fn()
+      .mockResolvedValue({ tag: "success", value: "http://test-url.com" }),
+  }),
+}));
+
+vi.mock("../../server", () => ({
+  pipelineQueue: {
+    add: vi.fn(),
+  },
+}));
+
+describe("Email Verification in Create Route", () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+
+    // Mock request context with minimal test env
+    app.use((req, _res, next) => {
+      req.context = {
+        env: {
+          OPENAI_API_KEY: "sk-test-key-123",
+          CLIENT_BASE_URL: "http://localhost:3000",
+          PYSERVER_URL: "http://localhost:8000",
+          GCLOUD_STORAGE_BUCKET: "test-bucket",
+          GOOGLE_CREDENTIALS_ENCODED: "test-google-credentials",
+          ALLOWED_GCS_BUCKETS: ["test-bucket"],
+          FIREBASE_CREDENTIALS_ENCODED: "test-firebase-credentials",
+          REDIS_URL: "redis://localhost:6379",
+          REDIS_QUEUE_NAME: "test-queue",
+          ALLOWED_ORIGINS: ["http://localhost:3000"],
+          NODE_ENV: "development" as const,
+          FEATURE_FLAG_PROVIDER: "local" as const,
+          FEATURE_FLAG_HOST: "https://us.i.posthog.com",
+          ANALYTICS_PROVIDER: "local" as const,
+          ANALYTICS_HOST: "https://app.posthog.com",
+          ANALYTICS_ENABLED: false,
+          ANALYTICS_FLUSH_AT: 20,
+          ANALYTICS_FLUSH_INTERVAL: 10000,
+          ANALYTICS_DEBUG: false,
+          RATE_LIMIT_PREFIX: "test",
+          PYSERVER_MAX_CONCURRENCY: 5,
+          PUBSUB_TOPIC_NAME: "test-topic",
+          PUBSUB_SUBSCRIPTION_NAME: "test-sub",
+        },
+      };
+      const mockLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+        fatal: vi.fn(),
+        child: vi.fn(),
+        level: "info",
+        silent: false,
+      } as any;
+
+      mockLogger.child.mockReturnValue(mockLogger);
+      req.log = mockLogger;
+      next();
+    });
+
+    app.post("/create", create);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default security mocks - allow data through
+    (validateParsedData as any).mockReturnValue({
+      tag: "success",
+      value: [],
+    });
+    (detectCSVInjection as any).mockReturnValue(false);
+  });
+
+  const createValidRequestBody = (csvData: any[]) => ({
+    firebaseAuthToken: "valid-token",
+    userConfig: {
+      title: "Test Report",
+      description: "Test Description",
+      systemInstructions: "Test System",
+      clusteringInstructions: "Test Clustering",
+      extractionInstructions: "Test Extraction",
+      dedupInstructions: "Test Dedup",
+      summariesInstructions: "Test Summaries",
+      cruxInstructions: "Test Crux",
+      cruxesEnabled: false,
+    },
+    data: ["csv", csvData],
+  });
+
+  it("should return AUTH_EMAIL_NOT_VERIFIED error for unverified email/password users", async () => {
+    // Mock an email/password user with unverified email
+    vi.mocked(firebase.verifyUser).mockResolvedValue({
+      uid: "test-user",
+      email: "test@example.com",
+      email_verified: false,
+      firebase: {
+        sign_in_provider: "password",
+        identities: {
+          email: ["test@example.com"],
+        },
+      },
+    } as any);
+
+    const cleanData = [
+      { comment: "Test comment", id: "1", interview: "Alice" },
+    ];
+
+    const response = await request(app)
+      .post("/create")
+      .send(createValidRequestBody(cleanData))
+      .expect(403); // AUTH_EMAIL_NOT_VERIFIED returns 403
+
+    expect(response.body.error.code).toBe("AUTH_EMAIL_NOT_VERIFIED");
+    expect(response.body.error.message).toBe(
+      "Please verify your email address to continue. Check your inbox for a verification link.",
+    );
+  });
+
+  // Test cases for users who SHOULD be allowed to create reports
+  describe("allowed user scenarios", () => {
+    const testCases = [
+      {
+        name: "verified email/password user",
+        user: {
+          uid: "test-user",
+          email: "test@example.com",
+          email_verified: true,
+          firebase: {
+            sign_in_provider: "password",
+            identities: { email: ["test@example.com"] },
+          },
+        },
+      },
+      {
+        name: "Google OAuth user",
+        user: {
+          uid: "test-user",
+          email: "test@gmail.com",
+          email_verified: true,
+          firebase: {
+            sign_in_provider: "google.com",
+            identities: {
+              "google.com": ["123456789"],
+              email: ["test@gmail.com"],
+            },
+          },
+        },
+      },
+      {
+        name: "legacy token without provider info",
+        user: {
+          uid: "test-user",
+          email: "test@example.com",
+        },
+      },
+    ];
+
+    it.each(testCases)(
+      "should allow $name to create reports",
+      async ({ user }) => {
+        vi.mocked(firebase.verifyUser).mockResolvedValue(user as any);
+
+        const response = await request(app)
+          .post("/create")
+          .send(
+            createValidRequestBody([
+              { comment: "Test", id: "1", interview: "Alice" },
+            ]),
+          )
+          .expect(200);
+
+        expect(response.body.message).toBe("Request received.");
+      },
+    );
+  });
+});

--- a/next-client/src/app/create/page.tsx
+++ b/next-client/src/app/create/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import CreateReport from "@/components/create/CreateReport";
 import { useUser } from "@/lib/hooks/getUser";
 import { Center } from "@/components/layout";
 import { Button, Spinner } from "@/components/elements";
-import { signInWithGoogle } from "@/lib/firebase/auth";
+import { SigninModal } from "@/components/create/components/Modals";
 import {
   Empty,
   EmptyHeader,
@@ -17,6 +18,7 @@ import { ExternalLink } from "lucide-react";
 
 export default function ReportCreationPage() {
   const { user, loading } = useUser();
+  const [showSignInModal, setShowSignInModal] = useState(false);
 
   if (loading) {
     return (
@@ -29,6 +31,10 @@ export default function ReportCreationPage() {
   if (user === null) {
     return (
       <Center>
+        <SigninModal
+          isOpen={showSignInModal}
+          onClose={() => setShowSignInModal(false)}
+        />
         <Empty className="border-0 bg-background p-8 rounded-lg max-w-sm">
           <EmptyHeader>
             <EmptyTitle>Sign in required</EmptyTitle>
@@ -39,8 +45,11 @@ export default function ReportCreationPage() {
 
           <EmptyContent>
             <div className="flex gap-2">
-              <Button onClick={() => signInWithGoogle()} variant="default">
-                Sign in with Google
+              <Button
+                onClick={() => setShowSignInModal(true)}
+                variant="default"
+              >
+                Sign in
               </Button>
               <Button asChild variant="outline">
                 <Link href="/">Homepage</Link>

--- a/next-client/src/app/error-test/page.tsx
+++ b/next-client/src/app/error-test/page.tsx
@@ -719,7 +719,7 @@ function SignInRequiredPreview() {
         <EmptyContent>
           <div className="flex gap-2">
             <Button onClick={(e) => e.preventDefault()} variant="default">
-              Sign in with Google
+              Sign in
             </Button>
             <Button variant="outline" onClick={(e) => e.preventDefault()}>
               Homepage

--- a/next-client/src/components/create/components/Modals.tsx
+++ b/next-client/src/components/create/components/Modals.tsx
@@ -8,7 +8,13 @@ import { logger } from "tttc-common/logger/browser";
 
 const signinModalLogger = logger.child({ module: "signin-modal" });
 
-export const SigninModal = ({ isOpen }: { isOpen: boolean }) => {
+export const SigninModal = ({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose?: () => void;
+}) => {
   const [authMode, setAuthMode] = useState<"signin" | "signup" | "reset">(
     "signin",
   );
@@ -22,8 +28,15 @@ export const SigninModal = ({ isOpen }: { isOpen: boolean }) => {
     }
   };
 
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setAuthMode("signin"); // Reset mode when closing
+      onClose?.();
+    }
+  };
+
   return (
-    <Dialog open={isOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent
         className="gap-2 p-6 z-[100] max-w-[400px]"
         overlayProps={{ className: "opacity-20 z-[90]" }}


### PR DESCRIPTION
**1. What is the goal of this PR?**

  - Force token refresh for email/password users on report creation to ensure server receives updated email_verified claim after verification
  - Return AUTH_EMAIL_NOT_VERIFIED (403) instead of INTERNAL_ERROR (500) when email verification is required
  - Update "Sign in with Google" to generic "Sign in" button that opens modal with all auth options

**2. What specific parts of T3C are you changing and how?**

next-client, express-server

**3. How did you test these changes?**

Tests, need to test in ephemeral for validation flow

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
