### PR TITLE
T3C-857: Fix hero image showing black square during loading

### DIFF
--- a/next-client/src/assets/hero/LandingHero.tsx
+++ b/next-client/src/assets/hero/LandingHero.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
+import { cn } from "@/lib/utils/shadcn";
 
 // Blur placeholder matching actual image aspect ratio (1764x1218 = 1.45:1)
 const blurDataURL =
@@ -9,7 +10,10 @@ const blurDataURL =
 
 export default function LandingHero({ className }: { className?: string }) {
   return (
-    <div className={className}>
+    <div
+      className={cn(className, "bg-slate-50")}
+      style={{ aspectRatio: "1764/1218" }} // Reserve space, prevent layout shift
+    >
       <Image
         src="/images/t3c-product-desktop-mobile.png"
         alt="Talk to the City product interface dashboard"


### PR DESCRIPTION
Add background color and aspect ratio to hero container so the blur placeholder is visible while loading. Previously appeared as black square because light blur was invisible against dark background.
