### PR TITLE
T3C-864: Fix MetadataLookupWarning in local development

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -38,6 +38,9 @@ module.exports = {
       restart_delay: 1000,
       env: {
         NODE_ENV: "development",
+        // Skip GCE metadata lookup to prevent MetadataLookupWarning in local dev
+        PUBSUB_EMULATOR_HOST: "localhost:8085",
+        METADATA_SERVER_DETECTION: "none",
       },
     },
     {

--- a/express-server/src/queue/providers/googlePubSub.ts
+++ b/express-server/src/queue/providers/googlePubSub.ts
@@ -19,11 +19,11 @@ export class GooglePubSubQueue implements Queue {
 
   constructor(topicName: string, subscriptionName: string, projectId?: string) {
     // Use emulator in development environment
+    // Note: PUBSUB_EMULATOR_HOST must be set before this runs (via PM2/env)
+    // to prevent MetadataLookupWarning from GCE credential detection
     const pubsubOptions: PubSubConfig = { projectId };
 
     if (process.env.NODE_ENV === "development") {
-      // Configure for Pub/Sub emulator
-      pubsubOptions.apiEndpoint = "localhost:8085";
       pubsubOptions.projectId = projectId || "dev-project";
     }
 


### PR DESCRIPTION
**1. What is the goal of this PR?**

Set METADATA_SERVER_DETECTION=none and PUBSUB_EMULATOR_HOST in PM2 ecosystem config to prevent Google Cloud libraries from attempting GCE metadata server lookups during local development.

The warning occurred because Google Auth library tries to detect credentials/project from the GCE metadata service, which doesn't exist in local dev environments.

**2. What specific parts of T3C are you changing and how?**

ecosystem, express-server

**3. How did you test these changes?**

Locally

Please add one or more reviewer(s) and tag them in a new post in the Slack dev channel :)
