### PR TITLE
T3C-75: Add report appendix with AI prompts display

### DIFF
--- a/common/morphisms/pipeline/tests/fixtures/testPipelineData.json
+++ b/common/morphisms/pipeline/tests/fixtures/testPipelineData.json
@@ -5,6 +5,8 @@
   "systemInstructions": "",
   "clusteringInstructions": "",
   "extractionInstructions": "",
+  "dedupInstructions": "",
+  "summariesInstructions": "",
   "batchSize": 0,
   "start": 0,
   "costs": 0,

--- a/common/prompts/index.ts
+++ b/common/prompts/index.ts
@@ -63,7 +63,7 @@ Now here is the list of topics/subtopics:
 \${taxonomy}
 
 And then here is the comment:
-\${comment} `;
+\${comment}`;
 
 export const defaultDedupPrompt = `You are grouping claims to help users understand which themes matter most in this consultation. Your goal is to consolidate similar claims into well-supported groups while preserving genuinely unique perspectives.
 
@@ -133,8 +133,7 @@ Return a JSON object of the form {
 Now here are the claims to group:
 \${claims}`;
 
-export const defaultSummariesPrompt = `
-I'm going to give you a single topic with its description, subtopics, and claims.
+export const defaultSummariesPrompt = `I'm going to give you a single topic with its description, subtopics, and claims.
 
 Generate a detailed summary (100-140 words) that:
 - Synthesizes the key themes and patterns across all subtopics

--- a/common/schema/index.ts
+++ b/common/schema/index.ts
@@ -787,6 +787,9 @@ export const llmPipelineOutput = z.object({
   systemInstructions: z.string(),
   clusteringInstructions: z.string(),
   extractionInstructions: z.string(),
+  dedupInstructions: z.string(),
+  summariesInstructions: z.string(),
+  cruxInstructions: z.string().optional(),
   batchSize: z.number(),
   tree: taxonomy,
   start: z.number(),
@@ -1210,6 +1213,22 @@ export const processingAuditLog = z.object({
 export type ProcessingAuditLog = z.infer<typeof processingAuditLog>;
 
 /********************************
+ * Prompts Used
+ * The actual prompts used when generating a report
+ ********************************/
+
+export const promptsUsed = z.object({
+  systemInstructions: z.string(),
+  clusteringInstructions: z.string(),
+  extractionInstructions: z.string(),
+  dedupInstructions: z.string(),
+  summariesInstructions: z.string(),
+  cruxInstructions: z.string().optional(),
+});
+
+export type PromptsUsed = z.infer<typeof promptsUsed>;
+
+/********************************
  * Pipeline output
  * What the object received from the LLM pipeline should look like.
  ********************************/
@@ -1218,6 +1237,7 @@ export const pipelineOutput = z.object({
   data: reportData,
   metadata: reportMetadata,
   auditLog: processingAuditLog.optional(),
+  promptsUsed: promptsUsed.optional(),
 });
 
 export type PipelineOutput = z.infer<typeof pipelineOutput>;

--- a/express-server/src/jobs/pipeline.ts
+++ b/express-server/src/jobs/pipeline.ts
@@ -417,12 +417,23 @@ export async function pipelineJob(job: PipelineJob) {
     const finalResult = mapResult(outputResult, (pipelineOutput) => {
       const result = llmPipelineToSchema(pipelineOutput);
 
+      // Add prompts used for report appendix
+      const promptsUsed: schema.PromptsUsed = {
+        systemInstructions: pipelineOutput.systemInstructions,
+        clusteringInstructions: pipelineOutput.clusteringInstructions,
+        extractionInstructions: pipelineOutput.extractionInstructions,
+        dedupInstructions: pipelineOutput.dedupInstructions,
+        summariesInstructions: pipelineOutput.summariesInstructions,
+        cruxInstructions: pipelineOutput.cruxInstructions,
+      };
+
       // Claim scoring happens after this, once IDs are assigned
-      // Add audit log if available
-      if (auditLog) {
-        return { ...result, auditLog };
-      }
-      return result;
+      // Add audit log and prompts
+      return {
+        ...result,
+        promptsUsed,
+        ...(auditLog && { auditLog }),
+      };
     });
 
     if (finalResult.tag === "success") {

--- a/next-client/__tests__/data/aiAssemblies.json
+++ b/next-client/__tests__/data/aiAssemblies.json
@@ -5,6 +5,8 @@
   "systemInstructions": "",
   "clusteringInstructions": "",
   "extractionInstructions": "",
+  "dedupInstructions": "",
+  "summariesInstructions": "",
   "batchSize": 0,
   "start": 0,
   "costs": 0,

--- a/next-client/src/components/elements/toggleText/ToggleText.tsx
+++ b/next-client/src/components/elements/toggleText/ToggleText.tsx
@@ -64,7 +64,7 @@ function Content({ children }: React.PropsWithChildren<{}>) {
   const { isOpen } = useContext(ToggleContext);
   return (
     <div className={`pl-5 ${!isOpen ? "hidden" : "block"}`}>
-      <p className="text-muted-foreground">{children}</p>
+      <div className="text-muted-foreground">{children}</div>
     </div>
   );
 }

--- a/next-client/src/components/report/Report.tsx
+++ b/next-client/src/components/report/Report.tsx
@@ -52,6 +52,17 @@ import { downloadReportData } from "@/lib/report/downloadUtils";
 import { ReportLayout } from "./components/ReportLayout";
 import { ReportHeader } from "./components/ReportHeader";
 import { ReportToolbar } from "./components/ReportToolbar";
+import { PromptToggle } from "./components/PromptToggle";
+
+// Default prompts for comparison
+import {
+  defaultSystemPrompt,
+  defaultClusteringPrompt,
+  defaultExtractionPrompt,
+  defaultDedupPrompt,
+  defaultSummariesPrompt,
+  defaultCruxPrompt,
+} from "tttc-common/prompts";
 
 /**
  * Report Component
@@ -718,8 +729,15 @@ function Appendix({
     }
   };
 
+  const prompts = rawPipelineOutput.promptsUsed;
+
+  // Normalize line endings for comparison (stored prompts may have \r\n)
+  const normalizePrompt = (s: string) => s.replace(/\r\n/g, "\n");
+  const promptsMatch = (stored: string, defaultPrompt: string) =>
+    normalizePrompt(stored) === normalizePrompt(defaultPrompt);
+
   return (
-    <Col className="p-8 appendix-section" gap={1}>
+    <Col className="p-8 appendix-section print:hidden" gap={2}>
       <p className="p-medium">Appendix</p>
       <p
         className="text-muted-foreground underline cursor-pointer"
@@ -727,6 +745,70 @@ function Appendix({
       >
         Download report in JSON
       </p>
+
+      {prompts && (
+        <Col gap={2}>
+          <p className="text-muted-foreground">
+            AI Prompts used to generate this report:
+          </p>
+          <PromptToggle
+            title="System prompt"
+            content={prompts.systemInstructions}
+            isDefault={promptsMatch(
+              prompts.systemInstructions,
+              defaultSystemPrompt,
+            )}
+            defaultContent={defaultSystemPrompt}
+          />
+          <PromptToggle
+            title="Topics and subtopics prompt"
+            content={prompts.clusteringInstructions}
+            isDefault={promptsMatch(
+              prompts.clusteringInstructions,
+              defaultClusteringPrompt,
+            )}
+            defaultContent={defaultClusteringPrompt}
+          />
+          <PromptToggle
+            title="Claim extraction prompt"
+            content={prompts.extractionInstructions}
+            isDefault={promptsMatch(
+              prompts.extractionInstructions,
+              defaultExtractionPrompt,
+            )}
+            defaultContent={defaultExtractionPrompt}
+          />
+          <PromptToggle
+            title="Merging claims prompt"
+            content={prompts.dedupInstructions}
+            isDefault={promptsMatch(
+              prompts.dedupInstructions,
+              defaultDedupPrompt,
+            )}
+            defaultContent={defaultDedupPrompt}
+          />
+          <PromptToggle
+            title="Summaries prompt"
+            content={prompts.summariesInstructions}
+            isDefault={promptsMatch(
+              prompts.summariesInstructions,
+              defaultSummariesPrompt,
+            )}
+            defaultContent={defaultSummariesPrompt}
+          />
+          {prompts.cruxInstructions && (
+            <PromptToggle
+              title="Cruxes prompt"
+              content={prompts.cruxInstructions}
+              isDefault={promptsMatch(
+                prompts.cruxInstructions,
+                defaultCruxPrompt,
+              )}
+              defaultContent={defaultCruxPrompt}
+            />
+          )}
+        </Col>
+      )}
     </Col>
   );
 }

--- a/next-client/src/components/report/components/PromptToggle.tsx
+++ b/next-client/src/components/report/components/PromptToggle.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import { ToggleText } from "@/components/elements";
+
+interface PromptToggleProps {
+  title: string;
+  content: string;
+  isDefault: boolean;
+  defaultContent?: string;
+}
+
+/**
+ * Collapsible component for displaying a prompt in the report appendix.
+ * Shows whether the prompt is the default or has been customized.
+ * When customized, offers a "Show default" toggle for comparison.
+ */
+export function PromptToggle({
+  title,
+  content,
+  isDefault,
+  defaultContent,
+}: PromptToggleProps) {
+  const [showDefault, setShowDefault] = useState(false);
+
+  return (
+    <ToggleText>
+      <ToggleText.Title>
+        {title}{" "}
+        <span className="text-muted-foreground text-sm font-normal">
+          ({isDefault ? "default" : "customized"})
+        </span>
+      </ToggleText.Title>
+      <ToggleText.Content>
+        <div className="flex flex-col gap-2">
+          <pre className="whitespace-pre-wrap font-sans text-sm">{content}</pre>
+          {!isDefault && defaultContent && (
+            <div className="mt-2">
+              <button
+                onClick={() => setShowDefault(!showDefault)}
+                className="text-sm text-muted-foreground underline cursor-pointer hover:text-foreground"
+              >
+                {showDefault ? "Hide default" : "Show default"}
+              </button>
+              {showDefault && (
+                <div className="mt-2 p-3 bg-muted/50 rounded-md border">
+                  <p className="text-xs text-muted-foreground mb-1">
+                    Default prompt:
+                  </p>
+                  <pre className="whitespace-pre-wrap font-sans text-sm text-muted-foreground">
+                    {defaultContent}
+                  </pre>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </ToggleText.Content>
+    </ToggleText>
+  );
+}

--- a/next-client/src/lib/report/__tests__/handleResponseData.integration.test.ts
+++ b/next-client/src/lib/report/__tests__/handleResponseData.integration.test.ts
@@ -177,6 +177,8 @@ describe("handleResponseData - Integration Tests", () => {
         systemInstructions: "Test instructions",
         clusteringInstructions: "Test clustering",
         extractionInstructions: "Test extraction",
+        dedupInstructions: "Test dedup",
+        summariesInstructions: "Test summaries",
         batchSize: 10,
         tree: [], // taxonomy is array of llmTopic
         start: Date.now(),


### PR DESCRIPTION
## Summary
- Add collapsible appendix section showing AI prompts used to generate each report
- Display whether each prompt is default or customized
- Show "Show default" toggle for customized prompts to allow comparison
- Store all 6 prompts (system, clustering, extraction, dedup, summaries, cruxes) in pipeline output
- Hide appendix in print view