### PR TITLE
T3C-874: Auto-restart PM2 services after building common

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dev:pubsub": "gcloud beta emulators pubsub start --host-port=localhost:8085",
     "dev:pyserver": "pyserver/.venv/bin/uvicorn --app-dir pyserver main:app --reload --host 0.0.0.0 --port 8000",
     "build": "pnpm -F tttc-common run build && pnpm -F '!tttc-common' -r run build",
-    "build:common": "pnpm -F tttc-common run build",
+    "build:common": "pnpm -F tttc-common run build && pm2 restart server client 2>/dev/null || true",
     "typecheck": "pnpm -F tttc-common run build && pnpm -F next-client exec tsc --noEmit && pnpm -F express-server exec tsc --noEmit",
     "test": "pnpm -r run test",
     "test:common": "pnpm -F tttc-common run test",


### PR DESCRIPTION
## Summary
- `pnpm build:common` now automatically restarts server and client PM2 services after a successful build
- Prevents stale chunk errors during development when common package changes
- Gracefully handles cases where PM2 isn't running (CI, concurrently mode)