### PR TITLE
T3C-883: Fix small hamburger icon on mobile

### DIFF
--- a/next-client/src/assets/icons/XSvg.tsx
+++ b/next-client/src/assets/icons/XSvg.tsx
@@ -1,28 +1,26 @@
 import type * as React from "react";
 
-const SvgComponent = (
-  props: React.SVGProps<SVGSVGElement & SVGPathElement>,
-) => (
+const SvgComponent = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
-    {...props}
-    width="40"
-    height="40"
-    viewBox="0 0 40 40"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
     <title>Close</title>
     <path
-      {...props}
-      d="M24 16L16 24"
-      stroke="#64748B"
+      d="M18 6L6 18"
+      stroke="currentColor"
+      strokeWidth="1.25"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
     <path
-      {...props}
-      d="M16 16L24 24"
-      stroke="#64748B"
+      d="M6 6L18 18"
+      stroke="currentColor"
+      strokeWidth="1.25"
       strokeLinecap="round"
       strokeLinejoin="round"
     />

--- a/next-client/src/components/elements/sheet/Sheet.tsx
+++ b/next-client/src/components/elements/sheet/Sheet.tsx
@@ -51,12 +51,14 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  hideCloseButton?: boolean;
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, hideCloseButton, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
@@ -65,10 +67,12 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
+      {!hideCloseButton && (
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      )}
     </SheetPrimitive.Content>
   </SheetPortal>
 ));

--- a/next-client/src/components/navbar/components/NavbarButtons.tsx
+++ b/next-client/src/components/navbar/components/NavbarButtons.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Icons from "@/assets/icons";
 import { Col, Row } from "@/components/layout";
 import {
@@ -84,25 +84,6 @@ export function CreateReport() {
 
 export function MobileHamburgerMenu() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  // Render a placeholder button during SSR to maintain layout
-  if (!isMounted) {
-    return (
-      <Button
-        variant={"ghost"}
-        className="size-10 visible md:hidden"
-        disabled
-        aria-label="Open menu"
-      >
-        <Icons.Menu />
-      </Button>
-    );
-  }
 
   return (
     <Sheet modal={false} open={isOpen} onOpenChange={(val) => setIsOpen(val)}>
@@ -113,16 +94,22 @@ export function MobileHamburgerMenu() {
       >
         <Button
           variant={"ghost"}
+          size={"icon"}
           className="size-10"
           aria-label={isOpen ? "Close menu" : "Open menu"}
         >
-          {isOpen ? <Icons.X /> : <Icons.Menu />}
+          {isOpen ? (
+            <Icons.X className="size-6" />
+          ) : (
+            <Icons.Menu className="size-6" />
+          )}
         </Button>
       </SheetTrigger>
       <SheetContent
         side={"bottom"}
-        className="h-[90vh]"
+        className="h-[90vh] p-6 pt-8"
         aria-describedby={undefined}
+        hideCloseButton
       >
         <SheetTitle className="sr-only">Navigation menu</SheetTitle>
         <Col className="flex h-full justify-between">
@@ -130,21 +117,21 @@ export function MobileHamburgerMenu() {
             <Link
               onClick={() => setIsOpen(false)}
               href={"/"}
-              className="p-3 min-h-[44px] flex items-center w-full self-center rounded-[6px]"
+              className="py-2 px-3 min-h-[44px] flex items-center w-full rounded-[6px] hover:bg-accent hover:text-primary"
             >
               <p>Home</p>
             </Link>
             <Link
               onClick={() => setIsOpen(false)}
               href={"/about"}
-              className="p-3 min-h-[44px] flex items-center w-full self-center rounded-[6px]"
+              className="py-2 px-3 min-h-[44px] flex items-center w-full rounded-[6px] hover:bg-accent hover:text-primary"
             >
               <p>About</p>
             </Link>
             <Link
               onClick={() => setIsOpen(false)}
               href={"https://github.com/aIObjectives/tttc-light-js"}
-              className="p-3 min-h-[44px] flex items-center w-full self-center rounded-[6px]"
+              className="py-2 px-3 min-h-[44px] flex items-center w-full rounded-[6px] hover:bg-accent hover:text-primary"
             >
               <p>Github</p>
             </Link>

--- a/next-client/src/components/report/components/ReportLayout.tsx
+++ b/next-client/src/components/report/components/ReportLayout.tsx
@@ -15,7 +15,7 @@ export const ToolBarFrame = ({
 }: React.PropsWithChildren<{ className?: string; stickyClass?: string }>) => (
   <Sticky
     className={cn(
-      `z-[70] w-full dark:bg-background bg-white pointer-events-auto`,
+      `z-40 w-full dark:bg-background bg-white pointer-events-auto`,
       className,
     )}
     stickyClass={cn("border-b shadow-sm pointer-events-auto", stickyClass)}


### PR DESCRIPTION
## Summary

- Fixed hamburger menu icon appearing too small on mobile viewports
- Root cause: Button's default size variant added excessive padding (`px-4 py-2` = 32px), leaving only 8px for the icon in a 40px container
- Added `size="icon"` prop for minimal padding and explicit `size-6` class (24px) to match Figma design