### PR TITLE
T3C-822: Change link button color to muted gray

### DIFF
--- a/next-client/src/components/copyButton/CopyButton.tsx
+++ b/next-client/src/components/copyButton/CopyButton.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { useContext } from "react";
 import { toast } from "sonner";
 import tailwind from "tailwind.config";
 import Icons from "@/assets/icons";
-import { type ColorVariant, getStrictColor } from "@/lib/color";
+import type { ColorVariant } from "@/lib/color";
 import { useThemeContextColor } from "@/lib/hooks/useTopicTheme";
 import { Button } from "../elements";
-import { TopicContext } from "../topic/Topic";
 
 const safeUseColor = (color: ColorVariant) => {
   try {
@@ -20,34 +18,8 @@ const safeUseColor = (color: ColorVariant) => {
 const themes = tailwind.theme.extend.colors;
 
 const themeColor = () => {
-  const { topicNode } = useContext(TopicContext);
-  if (!topicNode.id) {
-    return themes.muted.foreground;
-  }
-  const color = getStrictColor(topicNode.data.topicColor);
-
-  switch (color) {
-    case "blueSea":
-      return themes.theme_blueSea.DEFAULT;
-    case "blueSky":
-      return themes.theme_blueSky.DEFAULT;
-    case "brown":
-      return themes.theme_brown.DEFAULT;
-    case "greenLeaf":
-      return themes.theme_greenLeaf.DEFAULT;
-    case "greenLime":
-      return themes.theme_greenLime.DEFAULT;
-    case "purple":
-      return themes.theme_purple.DEFAULT;
-    case "red":
-      return themes.theme_red.DEFAULT;
-    case "violet":
-      return themes.theme_violet.DEFAULT;
-    case "yellow":
-      return themes.theme_yellow.DEFAULT;
-    default:
-      return themes.muted.foreground;
-  }
+  // T3C-822: Use muted gray for all link buttons to deprioritize them visually
+  return themes.muted.foreground;
 };
 
 function CopyButton({


### PR DESCRIPTION
## Summary

- Link buttons on reports now use muted gray instead of topic theme colors
- Deprioritizes links visually as requested in the ticket
- Removed unused imports after simplifying the color logic