### PR TITLE
T3C-920: Fix infinite loop in useHashChange hook

### DIFF
--- a/next-client/src/lib/hooks/useHashChange.ts
+++ b/next-client/src/lib/hooks/useHashChange.ts
@@ -3,8 +3,6 @@
 import { usePathname, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-// ! This component isn't being currently used. Mark for deletion.
-
 /**
  * Listens for url # changes
  */
@@ -13,22 +11,18 @@ export function useHashChange(format: "raw" | "decoded" = "decoded") {
   const _pathname = usePathname();
   const _searchParams = useSearchParams();
 
-  const decode = (hash: string) => decodeURIComponent(hash.slice(1));
-
-  const formatter: (str: string) => string =
-    format === "decoded" ? decode : (str: string) => str;
-
-  const handleHashChange = useCallback(
-    () => setHash(formatter(window.location.hash)),
-    [formatter],
-  );
+  const handleHashChange = useCallback(() => {
+    const rawHash = window.location.hash;
+    const formatted =
+      format === "decoded" ? decodeURIComponent(rawHash.slice(1)) : rawHash;
+    setHash(formatted);
+  }, [format]);
 
   useEffect(() => {
     // Set initial hash
     handleHashChange();
 
     // Listen for hash changes
-
     window.addEventListener("hashchange", handleHashChange);
 
     // Clean up


### PR DESCRIPTION
## Summary
- Fixes infinite render loop in `useHashChange` hook caused by inline function in `useCallback` dependency array

## Root Cause
The `formatter` function was defined in the component body (new reference every render), then used as a `useCallback` dependency. This caused:
1. `formatter` recreated → `handleHashChange` recreated → `useEffect` re-runs → `setHash()` called → re-render → repeat ∞

## Solution
Move formatting logic directly into `handleHashChange` and depend only on `format` (stable string primitive).

## Related
This is the same pattern fixed in T3C-868 commit `5fb91336` ("Fix infinite loops caused by inline functions in useEffect deps") but `useHashChange.ts` was missed.