### PR TITLE
T3C-936: Add next-env.d.ts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ package-lock.json
 # Build outputs
 dist
 .next
+next-client/next-env.d.ts
 storybook-static/
 *.tsbuildinfo
 

--- a/next-client/next-env.d.ts
+++ b/next-client/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Add `next-client/next-env.d.ts` to `.gitignore` per Next.js best practices
- Remove the file from git tracking

This file is auto-generated by Next.js and causes unnecessary git churn due to dynamic import lines that change based on dev server state.