### PR TITLE
T3C-942: Fix useReportSubscribe infinite loop regression

### DIFF
--- a/next-client/src/components/report/hooks/useReportSubscribe.ts
+++ b/next-client/src/components/report/hooks/useReportSubscribe.ts
@@ -26,10 +26,11 @@ function useReportSubscribe(
 
   // Triggers some side-effect when dispatch is called
   const useReportEffect = (func: (action: ReportStateAction) => void) => {
+    // biome-ignore lint/correctness/useExhaustiveDependencies: func is intentionally excluded - we want this effect to run only when actionState changes (when a dispatch happens), not on every render when func is recreated
     useEffect(() => {
       if (!actionState[0]) return;
       func(actionState[0]);
-    }, [func]);
+    }, [actionState]);
   };
 
   return [newDispatch, useReportEffect];


### PR DESCRIPTION
## Summary

- Fixes React error 185 ("Maximum update depth exceeded") on report pages
- Reverts incorrect dependency array change from Biome migration (T3C-868)
- Changed `[func]` back to `[actionState]` with explanatory biome-ignore comment

## Root Cause

The Biome PR accidentally changed the useEffect dependency from `[actionState]` to `[func]`. Since `func` is an inline arrow function recreated every render, this caused the effect to run on every render after any action was dispatched, eventually causing an infinite loop.

## Related

- T3C-920: Same class of bug in `useHashChange` (PR #487)
- T3C-943: Follow-up to refactor to ref pattern (blocked on React 19)

## Test plan

- [ ] Load a report page
- [ ] Interact with it (scroll, click topics, use outline navigation)
- [ ] Verify no crash after extended interaction