### PR TITLE
T3C-889: Replace AI Manifestos demo with crux/bridging version

### DIFF
--- a/next-client/src/components/landing/landing-config.ts
+++ b/next-client/src/components/landing/landing-config.ts
@@ -23,7 +23,7 @@ export const SAMPLE_REPORTS = [
   {
     title: "AI Manifestos",
     imageUri: "/images/sample-ai-manifestos.jpg",
-    resourceUrl: "/report/u1jxGWkhZwU3F6cthVKk",
+    resourceUrl: "/report/QQ4zmwM85f43EejP3QDT",
     date: "November 5, 2024",
   },
   {

--- a/utils/package.json
+++ b/utils/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "migrate-legacy": "tsx src/scripts/migrate-legacy-report.ts",
-    "analyze-audit": "tsx src/scripts/analyze-audit-log.ts"
+    "analyze-audit": "tsx src/scripts/analyze-audit-log.ts",
+    "transfer-ownership": "tsx src/scripts/transfer-report-ownership.ts",
+    "test": "vitest run"
   },
   "author": "AI Objectives Institute",
   "license": "Apache-2.0",

--- a/utils/src/scripts/migrate-legacy-report.ts
+++ b/utils/src/scripts/migrate-legacy-report.ts
@@ -41,38 +41,18 @@
  *   --help       Show this help message
  */
 
-import { resolve } from "node:path";
 import { Storage } from "@google-cloud/storage";
-import * as dotenv from "dotenv";
-import * as admin from "firebase-admin";
 import * as schema from "tttc-common/schema";
-import { z } from "zod";
-
-// Load environment from express-server/.env
-const envPath = resolve(process.cwd(), "../express-server/.env");
-dotenv.config({ path: envPath });
-
-// Validate required environment variables
-const envSchema = z.object({
-  FIREBASE_CREDENTIALS_ENCODED: z.string().min(1),
-  GOOGLE_CREDENTIALS_ENCODED: z.string().min(1),
-  LEGACY_REPORT_USER_ID: z.string().min(1),
-  NODE_ENV: z.enum(["development", "production"]).default("development"),
-});
-
-type Env = z.infer<typeof envSchema>;
-
-// Collection name (from common/firebase)
-const REPORT_REF_COLLECTION = "reportRef";
+import {
+  admin,
+  type Env,
+  getCollectionName,
+  initializeFirebase as initializeFirebaseBase,
+  validateEnvironment,
+} from "./shared/firebase-admin";
 
 // Schema version for legacy reports
 const LEGACY_REPORT_SCHEMA_VERSION = 1;
-
-const getCollectionName = (env: Env) => {
-  return env.NODE_ENV === "production"
-    ? REPORT_REF_COLLECTION
-    : `${REPORT_REF_COLLECTION}_dev`;
-};
 
 /**
  * Parse GCS URI into bucket and fileName
@@ -176,61 +156,15 @@ function extractMetadata(reportData: schema.PipelineOutput): {
 }
 
 /**
- * Validate and return environment configuration
- */
-function validateEnvironment(): Env {
-  console.log("\nValidating environment...");
-  const envResult = envSchema.safeParse(process.env);
-  if (!envResult.success) {
-    console.error("ERROR: Environment validation failed:");
-    console.error(envResult.error.format());
-    console.error("\nMissing or invalid environment variables:");
-    console.error("- FIREBASE_CREDENTIALS_ENCODED (from express-server/.env)");
-    console.error("- GOOGLE_CREDENTIALS_ENCODED (from express-server/.env)");
-    console.error(
-      "- LEGACY_REPORT_USER_ID (create owner user first, see script header)",
-    );
-    throw new Error("Environment validation failed");
-  }
-  const env = envResult.data;
-  console.log(`   Environment: ${env.NODE_ENV}`);
-  console.log(`   Owner User ID: ${env.LEGACY_REPORT_USER_ID}`);
-  return env;
-}
-
-/**
- * Initialize Firebase Admin and validate user
+ * Initialize Firebase Admin with GCS Storage support
+ * Extends the base initializeFirebase with Storage client
  */
 async function initializeFirebase(env: Env): Promise<{
   app: admin.app.App;
   db: admin.firestore.Firestore;
   storage: Storage;
 }> {
-  console.log("\nInitializing Firebase...");
-  const firebaseCredentials = JSON.parse(
-    Buffer.from(env.FIREBASE_CREDENTIALS_ENCODED, "base64").toString("utf-8"),
-  );
-  const app = admin.apps.length
-    ? admin.app()
-    : admin.initializeApp({
-        credential: admin.credential.cert(firebaseCredentials),
-      });
-  const db = admin.firestore(app);
-  console.log("   Firebase initialized");
-
-  // Validate user exists
-  console.log("\nValidating owner user...");
-  try {
-    const userRecord = await admin.auth(app).getUser(env.LEGACY_REPORT_USER_ID);
-    console.log(`   User verified: ${userRecord.email || userRecord.uid}`);
-  } catch (_error) {
-    console.error("ERROR: Owner user not found in Firebase Auth");
-    console.error(`   User ID: ${env.LEGACY_REPORT_USER_ID}`);
-    console.error(
-      "   Create the user in Firebase Console (Authentication > Users)",
-    );
-    throw new Error("Owner user not found in Firebase Auth");
-  }
+  const { app, db } = await initializeFirebaseBase(env);
 
   // Initialize GCS (using separate GCP credentials, not Firebase credentials)
   console.log("\nInitializing Google Cloud Storage...");

--- a/utils/src/scripts/shared/__tests__/firebase-admin.test.ts
+++ b/utils/src/scripts/shared/__tests__/firebase-admin.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { Env } from "../firebase-admin";
+import {
+  envSchema,
+  getCollectionName,
+  REPORT_REF_COLLECTION,
+} from "../firebase-admin";
+
+describe("firebase-admin shared utilities", () => {
+  describe("REPORT_REF_COLLECTION", () => {
+    it("should be 'reportRef'", () => {
+      expect(REPORT_REF_COLLECTION).toBe("reportRef");
+    });
+  });
+
+  describe("getCollectionName", () => {
+    it("should return 'reportRef' for production environment", () => {
+      const env: Env = {
+        FIREBASE_CREDENTIALS_ENCODED: "encoded",
+        GOOGLE_CREDENTIALS_ENCODED: "encoded",
+        LEGACY_REPORT_USER_ID: "user123",
+        NODE_ENV: "production",
+      };
+      expect(getCollectionName(env)).toBe("reportRef");
+    });
+
+    it("should return 'reportRef_dev' for development environment", () => {
+      const env: Env = {
+        FIREBASE_CREDENTIALS_ENCODED: "encoded",
+        GOOGLE_CREDENTIALS_ENCODED: "encoded",
+        LEGACY_REPORT_USER_ID: "user123",
+        NODE_ENV: "development",
+      };
+      expect(getCollectionName(env)).toBe("reportRef_dev");
+    });
+  });
+
+  describe("envSchema", () => {
+    it("should validate a complete environment object", () => {
+      const validEnv = {
+        FIREBASE_CREDENTIALS_ENCODED: "base64encoded",
+        GOOGLE_CREDENTIALS_ENCODED: "base64encoded",
+        LEGACY_REPORT_USER_ID: "firebase-uid-123",
+        NODE_ENV: "production",
+      };
+
+      const result = envSchema.safeParse(validEnv);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.NODE_ENV).toBe("production");
+      }
+    });
+
+    it("should default NODE_ENV to development when not provided", () => {
+      const envWithoutNodeEnv = {
+        FIREBASE_CREDENTIALS_ENCODED: "base64encoded",
+        GOOGLE_CREDENTIALS_ENCODED: "base64encoded",
+        LEGACY_REPORT_USER_ID: "firebase-uid-123",
+      };
+
+      const result = envSchema.safeParse(envWithoutNodeEnv);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.NODE_ENV).toBe("development");
+      }
+    });
+
+    it("should fail when FIREBASE_CREDENTIALS_ENCODED is missing", () => {
+      const invalidEnv = {
+        GOOGLE_CREDENTIALS_ENCODED: "base64encoded",
+        LEGACY_REPORT_USER_ID: "firebase-uid-123",
+      };
+
+      const result = envSchema.safeParse(invalidEnv);
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail when GOOGLE_CREDENTIALS_ENCODED is missing", () => {
+      const invalidEnv = {
+        FIREBASE_CREDENTIALS_ENCODED: "base64encoded",
+        LEGACY_REPORT_USER_ID: "firebase-uid-123",
+      };
+
+      const result = envSchema.safeParse(invalidEnv);
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail when LEGACY_REPORT_USER_ID is missing", () => {
+      const invalidEnv = {
+        FIREBASE_CREDENTIALS_ENCODED: "base64encoded",
+        GOOGLE_CREDENTIALS_ENCODED: "base64encoded",
+      };
+
+      const result = envSchema.safeParse(invalidEnv);
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail when FIREBASE_CREDENTIALS_ENCODED is empty", () => {
+      const invalidEnv = {
+        FIREBASE_CREDENTIALS_ENCODED: "",
+        GOOGLE_CREDENTIALS_ENCODED: "base64encoded",
+        LEGACY_REPORT_USER_ID: "firebase-uid-123",
+      };
+
+      const result = envSchema.safeParse(invalidEnv);
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail for invalid NODE_ENV values", () => {
+      const invalidEnv = {
+        FIREBASE_CREDENTIALS_ENCODED: "base64encoded",
+        GOOGLE_CREDENTIALS_ENCODED: "base64encoded",
+        LEGACY_REPORT_USER_ID: "firebase-uid-123",
+        NODE_ENV: "staging",
+      };
+
+      const result = envSchema.safeParse(invalidEnv);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/utils/src/scripts/shared/firebase-admin.ts
+++ b/utils/src/scripts/shared/firebase-admin.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared Firebase Admin utilities for CLI scripts
+ *
+ * This module provides common functionality for scripts that need to interact
+ * with Firebase Admin SDK, including environment validation and initialization.
+ */
+
+import { resolve } from "node:path";
+import * as dotenv from "dotenv";
+import * as admin from "firebase-admin";
+import { z } from "zod";
+
+// Load environment from express-server/.env
+const envPath = resolve(process.cwd(), "../express-server/.env");
+dotenv.config({ path: envPath });
+
+// Validate required environment variables
+export const envSchema = z.object({
+  FIREBASE_CREDENTIALS_ENCODED: z.string().min(1),
+  GOOGLE_CREDENTIALS_ENCODED: z.string().min(1),
+  LEGACY_REPORT_USER_ID: z.string().min(1),
+  NODE_ENV: z.enum(["development", "production"]).default("development"),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+// Collection name (from common/firebase)
+export const REPORT_REF_COLLECTION = "reportRef";
+
+/**
+ * Get the Firestore collection name based on environment
+ */
+export function getCollectionName(env: Env): string {
+  return env.NODE_ENV === "production"
+    ? REPORT_REF_COLLECTION
+    : `${REPORT_REF_COLLECTION}_dev`;
+}
+
+/**
+ * Validate and return environment configuration
+ */
+export function validateEnvironment(): Env {
+  console.log("\nValidating environment...");
+  const envResult = envSchema.safeParse(process.env);
+  if (!envResult.success) {
+    console.error("ERROR: Environment validation failed:");
+    console.error(envResult.error.format());
+    console.error("\nMissing or invalid environment variables:");
+    console.error("- FIREBASE_CREDENTIALS_ENCODED (from express-server/.env)");
+    console.error("- GOOGLE_CREDENTIALS_ENCODED (from express-server/.env)");
+    console.error(
+      "- LEGACY_REPORT_USER_ID (create owner user first, see script header)",
+    );
+    throw new Error("Environment validation failed");
+  }
+  const env = envResult.data;
+  console.log(`   Environment: ${env.NODE_ENV}`);
+  console.log(`   Owner User ID: ${env.LEGACY_REPORT_USER_ID}`);
+  return env;
+}
+
+/**
+ * Initialize Firebase Admin and validate user
+ */
+export async function initializeFirebase(env: Env): Promise<{
+  app: admin.app.App;
+  db: admin.firestore.Firestore;
+}> {
+  console.log("\nInitializing Firebase...");
+  const firebaseCredentials = JSON.parse(
+    Buffer.from(env.FIREBASE_CREDENTIALS_ENCODED, "base64").toString("utf-8"),
+  );
+  const app = admin.apps.length
+    ? admin.app()
+    : admin.initializeApp({
+        credential: admin.credential.cert(firebaseCredentials),
+      });
+  const db = admin.firestore(app);
+  console.log("   Firebase initialized");
+
+  // Validate user exists
+  console.log("\nValidating owner user...");
+  try {
+    const userRecord = await admin.auth(app).getUser(env.LEGACY_REPORT_USER_ID);
+    console.log(`   User verified: ${userRecord.email || userRecord.uid}`);
+  } catch (_error) {
+    console.error("ERROR: Owner user not found in Firebase Auth");
+    console.error(`   User ID: ${env.LEGACY_REPORT_USER_ID}`);
+    console.error(
+      "   Create the user in Firebase Console (Authentication > Users)",
+    );
+    throw new Error("Owner user not found in Firebase Auth");
+  }
+
+  return { app, db };
+}
+
+// Re-export firebase-admin for scripts that need additional functionality
+export { admin };

--- a/utils/src/scripts/transfer-report-ownership.ts
+++ b/utils/src/scripts/transfer-report-ownership.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env tsx
+
+/**
+ * Transfer ownership of a report to the configured demo user
+ *
+ * This script transfers ownership of an existing report in Firestore to the
+ * user specified by LEGACY_REPORT_USER_ID. Use this for:
+ * - Consolidating demo reports under a single demo account
+ * - Reassigning reports created during testing to the proper owner
+ *
+ * Prerequisites:
+ * 1. Ensure express-server/.env has the required credentials:
+ *    - FIREBASE_CREDENTIALS_ENCODED: Firebase Admin SDK credentials
+ * 2. Set LEGACY_REPORT_USER_ID in express-server/.env
+ *    - The Firebase UID of the target owner
+ *    - The UID can be found in Firebase Console (Authentication > Users)
+ *
+ * Usage (from repository root):
+ *   pnpm -F utils transfer-ownership -- --dry-run QQ4zmwM85f43EejP3QDT
+ *   pnpm -F utils transfer-ownership -- --force QQ4zmwM85f43EejP3QDT
+ *
+ * Or from utils directory:
+ *   cd utils && pnpm transfer-ownership -- --force QQ4zmwM85f43EejP3QDT
+ *
+ * Options:
+ *   --dry-run    Preview the transfer without writing to Firestore
+ *   --force      Confirm and execute the ownership transfer
+ *   --help       Show this help message
+ */
+
+import {
+  admin,
+  getCollectionName,
+  initializeFirebase,
+  validateEnvironment,
+} from "./shared/firebase-admin";
+
+/**
+ * Transfer ownership of a report to the configured user
+ */
+async function transferOwnership(
+  reportId: string,
+  dryRun: boolean = false,
+  forceUpdate: boolean = false,
+): Promise<void> {
+  console.log(`\nTransferring ownership for report: ${reportId}`);
+
+  // Setup
+  const env = validateEnvironment();
+  const { db } = await initializeFirebase(env);
+
+  // Look up report by document ID
+  console.log("\nLooking up report...");
+  const collectionName = getCollectionName(env);
+  const reportDoc = await db.collection(collectionName).doc(reportId).get();
+
+  if (!reportDoc.exists) {
+    console.error(`ERROR: Report not found: ${reportId}`);
+    console.error(`   Collection: ${collectionName}`);
+    console.error("   Verify the report ID is correct and exists in Firestore");
+    throw new Error("Report not found");
+  }
+
+  const reportData = reportDoc.data();
+  if (!reportData) {
+    throw new Error("Report data is empty");
+  }
+
+  const currentOwnerId = reportData.userId;
+  const reportTitle = reportData.title || "(no title)";
+
+  console.log(`   Found report: ${reportTitle}`);
+  console.log(`   Document ID: ${reportId}`);
+  console.log(`   Current owner: ${currentOwnerId}`);
+  console.log(`   URL: /report/${reportId}`);
+
+  // Check if ownership already matches
+  if (currentOwnerId === env.LEGACY_REPORT_USER_ID) {
+    console.log("\nReport already owned by target user - no action needed");
+    return;
+  }
+
+  // Show ownership change
+  console.log(`\nOwnership transfer:`);
+  console.log(`   From: ${currentOwnerId}`);
+  console.log(`   To:   ${env.LEGACY_REPORT_USER_ID}`);
+
+  // Handle dry run
+  if (dryRun) {
+    console.log("\nDRY RUN MODE - No changes will be made");
+    console.log(`   Would update userId from: ${currentOwnerId}`);
+    console.log(`   To: ${env.LEGACY_REPORT_USER_ID}`);
+    console.log("\nTo execute the transfer, re-run with --force flag");
+    return;
+  }
+
+  // Require --force flag for ownership transfer
+  if (!forceUpdate) {
+    console.log(
+      "\nWARNING: Report ownership will be transferred to a different user.",
+    );
+    console.log(
+      "To proceed with ownership transfer, re-run with --force flag:",
+    );
+    console.log(`  pnpm -F utils transfer-ownership -- --force "${reportId}"`);
+    throw new Error("Ownership transfer requires --force flag");
+  }
+
+  // Update ownership
+  console.log("\nUpdating report ownership...");
+  await reportDoc.ref.update({
+    userId: env.LEGACY_REPORT_USER_ID,
+    lastStatusUpdate: admin.firestore.Timestamp.now(),
+  });
+
+  console.log("   Ownership updated successfully");
+  console.log(`\nTransfer complete!`);
+  console.log(`\nReport URL: /report/${reportId}`);
+  console.log(
+    `   Ownership transferred from ${currentOwnerId} to ${env.LEGACY_REPORT_USER_ID}`,
+  );
+}
+
+// Parse CLI arguments
+const args = process.argv.slice(2);
+
+if (args.includes("--help") || args.length === 0) {
+  console.log(`
+Transfer ownership of a report to the configured demo user
+
+Usage (from repository root):
+  pnpm -F utils transfer-ownership -- --dry-run <reportId>
+  pnpm -F utils transfer-ownership -- --force <reportId>
+
+Options:
+  --dry-run    Preview the transfer without writing to Firestore
+  --force      Confirm and execute the ownership transfer
+  --help       Show this help message
+
+Example:
+  pnpm -F utils transfer-ownership -- --dry-run QQ4zmwM85f43EejP3QDT
+  pnpm -F utils transfer-ownership -- --force QQ4zmwM85f43EejP3QDT
+
+The target owner is configured via LEGACY_REPORT_USER_ID in express-server/.env
+`);
+  process.exit(0);
+}
+
+const dryRun = args.includes("--dry-run");
+const forceUpdate = args.includes("--force");
+
+const reportId = args.find((arg) => !arg.startsWith("--"));
+
+if (!reportId) {
+  console.error("ERROR: Report ID required");
+  console.error(
+    'Usage: pnpm -F utils transfer-ownership -- --force "reportId"',
+  );
+  console.error("Run with --help for more information");
+  process.exit(1);
+}
+
+// Run transfer
+transferOwnership(reportId, dryRun, forceUpdate)
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error("\nERROR:", error.message || error);
+    process.exit(1);
+  });

--- a/utils/vitest.config.ts
+++ b/utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary

- Update homepage demo link to new report with crux/bridging features (`QQ4zmwM85f43EejP3QDT`)
- Extract shared Firebase Admin utilities for CLI scripts (reduces code duplication)
- Add `transfer-report-ownership` script for direct ID-based ownership changes
- Refactor `migrate-legacy-report` to use shared module
- Add tests for shared utilities (10 tests)
- Transfer ownership of new report to demo user (`demoreports@objective.is`)

## Changes

| File | Change |
|------|--------|
| `landing-config.ts` | Update AI Manifestos demo URL |
| `shared/firebase-admin.ts` | New shared utilities module |
| `firebase-admin.test.ts` | Tests for shared utilities |
| `transfer-report-ownership.ts` | New script for ownership transfers |
| `migrate-legacy-report.ts` | Refactored to use shared module |
| `utils/package.json` | Added scripts |

Closes T3C-889