### PR TITLE
T3C-896: Centralize auth middleware

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Build, typecheck, and test all packages
         env:
+          NODE_ENV: test
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           OPENAI_API_KEY: dummy-key-for-ci

--- a/common/firebase/index.ts
+++ b/common/firebase/index.ts
@@ -170,7 +170,7 @@ export const SCHEMA_VERSIONS = {
 } as const;
 
 export const useGetCollectionName =
-  (NODE_ENV: "development" | "production") =>
+  (NODE_ENV: "development" | "production" | "test") =>
   (name: keyof typeof COLLECTIONS) => {
     return NODE_ENV === "production"
       ? COLLECTIONS[name]

--- a/express-server/src/__tests__/authMiddleware.test.ts
+++ b/express-server/src/__tests__/authMiddleware.test.ts
@@ -1,0 +1,260 @@
+import type { NextFunction, Response } from "express";
+import type { DecodedIdToken } from "firebase-admin/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "../middleware";
+import type { RequestWithAuth, RequestWithLogger } from "../types/request";
+
+// Mock Firebase module
+vi.mock("../Firebase", () => ({
+  verifyUser: vi.fn(),
+}));
+
+// Mock sendError module
+vi.mock("../routes/sendError", () => ({
+  sendErrorByCode: vi.fn(),
+}));
+
+describe("authMiddleware", () => {
+  let mockReq: RequestWithLogger;
+  let mockRes: Response;
+  let mockNext: NextFunction;
+  let mockVerifyUser: ReturnType<typeof vi.fn>;
+  let mockSendErrorByCode: ReturnType<typeof vi.fn>;
+
+  const createMockDecodedToken = (
+    uid = "test-uid",
+    email = "test@example.com",
+  ): DecodedIdToken =>
+    ({
+      uid,
+      email,
+      aud: "test-project",
+      auth_time: Date.now(),
+      exp: Date.now() + 3600,
+      iat: Date.now(),
+      iss: "https://securetoken.google.com/test-project",
+      sub: uid,
+    }) as DecodedIdToken;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Get mocked functions
+    const firebase = await import("../Firebase");
+    mockVerifyUser = vi.mocked(firebase.verifyUser);
+
+    const sendError = await import("../routes/sendError");
+    mockSendErrorByCode = vi.mocked(sendError.sendErrorByCode);
+
+    // Create mock request with logger
+    mockReq = {
+      headers: {},
+      body: {},
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    } as unknown as RequestWithLogger;
+
+    // Create mock response
+    mockRes = {
+      status: vi.fn(() => mockRes),
+      json: vi.fn(),
+    } as unknown as Response;
+
+    // Create mock next function
+    mockNext = vi.fn();
+  });
+
+  describe("header-based token extraction", () => {
+    it("should extract Bearer token from Authorization header", async () => {
+      mockReq.headers.authorization = "Bearer valid-token";
+      mockVerifyUser.mockResolvedValue(createMockDecodedToken());
+
+      const middleware = authMiddleware({ tokenLocation: "header" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockVerifyUser).toHaveBeenCalledWith("valid-token");
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it("should trim extra spaces after Bearer", async () => {
+      mockReq.headers.authorization = "Bearer   token-with-spaces";
+      mockVerifyUser.mockResolvedValue(createMockDecodedToken());
+
+      const middleware = authMiddleware({ tokenLocation: "header" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      // Trims leading/trailing whitespace per RFC 6750
+      expect(mockVerifyUser).toHaveBeenCalledWith("token-with-spaces");
+    });
+
+    it("should reject missing Authorization header", async () => {
+      mockReq.headers.authorization = undefined;
+
+      const middleware = authMiddleware({ tokenLocation: "header" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockSendErrorByCode).toHaveBeenCalledWith(
+        mockRes,
+        "AUTH_TOKEN_MISSING",
+        mockReq.log,
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should reject non-Bearer authorization", async () => {
+      mockReq.headers.authorization = "Basic dXNlcjpwYXNz";
+
+      const middleware = authMiddleware({ tokenLocation: "header" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockSendErrorByCode).toHaveBeenCalledWith(
+        mockRes,
+        "AUTH_TOKEN_MISSING",
+        mockReq.log,
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should reject Bearer with no token", async () => {
+      mockReq.headers.authorization = "Bearer ";
+
+      const middleware = authMiddleware({ tokenLocation: "header" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockSendErrorByCode).toHaveBeenCalledWith(
+        mockRes,
+        "AUTH_TOKEN_MISSING",
+        mockReq.log,
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("body-based token extraction", () => {
+    it("should extract firebaseAuthToken from request body", async () => {
+      mockReq.body = { firebaseAuthToken: "body-token" };
+      mockVerifyUser.mockResolvedValue(createMockDecodedToken());
+
+      const middleware = authMiddleware({ tokenLocation: "body" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockVerifyUser).toHaveBeenCalledWith("body-token");
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it("should reject missing firebaseAuthToken in body", async () => {
+      mockReq.body = { otherField: "value" };
+
+      const middleware = authMiddleware({ tokenLocation: "body" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockSendErrorByCode).toHaveBeenCalledWith(
+        mockRes,
+        "AUTH_TOKEN_MISSING",
+        mockReq.log,
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should reject undefined body", async () => {
+      mockReq.body = undefined;
+
+      const middleware = authMiddleware({ tokenLocation: "body" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockSendErrorByCode).toHaveBeenCalledWith(
+        mockRes,
+        "AUTH_TOKEN_MISSING",
+        mockReq.log,
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("token verification", () => {
+    it("should attach decoded user to req.auth on success", async () => {
+      const decodedToken = createMockDecodedToken("user-123", "user@test.com");
+      mockReq.headers.authorization = "Bearer valid-token";
+      mockVerifyUser.mockResolvedValue(decodedToken);
+
+      const middleware = authMiddleware({ tokenLocation: "header" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect((mockReq as RequestWithAuth).auth).toEqual(decodedToken);
+      expect((mockReq as RequestWithAuth).auth.uid).toBe("user-123");
+      expect((mockReq as RequestWithAuth).auth.email).toBe("user@test.com");
+    });
+
+    it("should return AUTH_TOKEN_INVALID when verification fails", async () => {
+      mockReq.headers.authorization = "Bearer invalid-token";
+      mockVerifyUser.mockRejectedValue(new Error("Token expired"));
+
+      const middleware = authMiddleware({ tokenLocation: "header" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockSendErrorByCode).toHaveBeenCalledWith(
+        mockRes,
+        "AUTH_TOKEN_INVALID",
+        mockReq.log,
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it("should log warning when verification fails", async () => {
+      const tokenError = new Error("Firebase auth error");
+      mockReq.headers.authorization = "Bearer bad-token";
+      mockVerifyUser.mockRejectedValue(tokenError);
+
+      const middleware = authMiddleware({ tokenLocation: "header" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockReq.log.warn).toHaveBeenCalledWith(
+        { error: tokenError },
+        "Token verification failed",
+      );
+    });
+  });
+
+  describe("logging", () => {
+    it("should log warning with tokenLocation when token is missing", async () => {
+      mockReq.headers.authorization = undefined;
+
+      const middleware = authMiddleware({ tokenLocation: "header" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockReq.log.warn).toHaveBeenCalledWith(
+        { tokenLocation: "header" },
+        "Auth token missing",
+      );
+    });
+
+    it("should include body tokenLocation in missing token log", async () => {
+      mockReq.body = {};
+
+      const middleware = authMiddleware({ tokenLocation: "body" });
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockReq.log.warn).toHaveBeenCalledWith(
+        { tokenLocation: "body" },
+        "Auth token missing",
+      );
+    });
+  });
+
+  describe("default options", () => {
+    it("should default to header-based extraction", async () => {
+      mockReq.headers.authorization = "Bearer default-token";
+      mockVerifyUser.mockResolvedValue(createMockDecodedToken());
+
+      const middleware = authMiddleware();
+      await middleware(mockReq, mockRes, mockNext);
+
+      expect(mockVerifyUser).toHaveBeenCalledWith("default-token");
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+});

--- a/express-server/src/__tests__/validateOpenAIApiKeyHeader.test.ts
+++ b/express-server/src/__tests__/validateOpenAIApiKeyHeader.test.ts
@@ -2,7 +2,13 @@ import express from "express";
 import pinoHttp from "pino-http";
 import request from "supertest";
 import { logger } from "tttc-common/logger";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock Firebase to avoid initialization with dummy credentials
+vi.mock("../Firebase", () => ({
+  verifyUser: vi.fn(),
+}));
+
 import { validateOpenAIApiKeyHeader } from "../middleware";
 
 describe("validateOpenAIApiKeyHeader middleware", () => {

--- a/express-server/src/middleware.ts
+++ b/express-server/src/middleware.ts
@@ -1,6 +1,9 @@
 import type { NextFunction, Request, Response } from "express";
+import { ERROR_CODES } from "tttc-common/errors";
+import { verifyUser } from "./Firebase";
+import { sendErrorByCode } from "./routes/sendError";
 import type { Env } from "./types/context";
-import type { RequestWithLogger } from "./types/request";
+import type { RequestWithAuth, RequestWithLogger } from "./types/request";
 
 /**
  * Adds context to the request object
@@ -172,5 +175,62 @@ export const validateOpenAIApiKeyHeader = () => {
     req.headers["x-openai-api-key"] = sanitizedKey;
 
     next();
+  };
+};
+
+/**
+ * Configuration options for auth middleware
+ */
+interface AuthMiddlewareOptions {
+  /** Where to extract the token from */
+  tokenLocation: "header" | "body";
+}
+
+/**
+ * Extracts Bearer token from Authorization header
+ * Trims whitespace from the extracted token per RFC 6750
+ */
+function extractBearerToken(authHeader: string | undefined): string | null {
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  const token = authHeader.slice(7).trim();
+  return token || null;
+}
+
+/**
+ * Authentication middleware that validates Firebase ID tokens.
+ *
+ * Supports two token locations:
+ * - "header": Extracts from Authorization: Bearer <token>
+ * - "body": Extracts from request body firebaseAuthToken field
+ *
+ * On success, attaches decoded user to req.auth.
+ * On failure, sends an error response (AUTH_TOKEN_MISSING or AUTH_TOKEN_INVALID).
+ */
+export const authMiddleware = (
+  options: AuthMiddlewareOptions = { tokenLocation: "header" },
+) => {
+  return async (req: RequestWithLogger, res: Response, next: NextFunction) => {
+    // Extract token based on location
+    const token =
+      options.tokenLocation === "header"
+        ? extractBearerToken(req.headers.authorization)
+        : req.body?.firebaseAuthToken;
+
+    if (!token) {
+      req.log.warn(
+        { tokenLocation: options.tokenLocation },
+        "Auth token missing",
+      );
+      return sendErrorByCode(res, ERROR_CODES.AUTH_TOKEN_MISSING, req.log);
+    }
+
+    try {
+      const decodedUser = await verifyUser(token);
+      (req as RequestWithAuth).auth = decodedUser;
+      next();
+    } catch (error) {
+      req.log.warn({ error }, "Token verification failed");
+      return sendErrorByCode(res, ERROR_CODES.AUTH_TOKEN_INVALID, req.log);
+    }
   };
 };

--- a/express-server/src/server.ts
+++ b/express-server/src/server.ts
@@ -17,7 +17,7 @@ import {
   shutdownAnalyticsClient,
 } from "./analytics";
 import { initializeFeatureFlags, shutdownFeatureFlags } from "./featureFlags";
-import { contextMiddleware } from "./middleware";
+import { authMiddleware, contextMiddleware } from "./middleware";
 import { createQueue } from "./queue";
 import authEvents from "./routes/authEvents";
 import create from "./routes/create";
@@ -257,13 +257,23 @@ app.post("/create", reportLimiter, create);
  * Ensures user document exists in Firestore
  * Uses authLimiter (5000 req/15min per IP) - critical path for user authentication
  */
-app.post("/ensure-user", authLimiter, ensureUser);
+app.post(
+  "/ensure-user",
+  authLimiter,
+  authMiddleware({ tokenLocation: "body" }),
+  ensureUser as unknown as express.RequestHandler,
+);
 
 /**
  * Submits user feedback
  * Uses authLimiter (5000 req/15min per IP)
  */
-app.post("/feedback", authLimiter, feedback);
+app.post(
+  "/feedback",
+  authLimiter,
+  authMiddleware({ tokenLocation: "body" }),
+  feedback as unknown as express.RequestHandler,
+);
 
 /**
  * Logs authentication events (signin/signout)
@@ -280,13 +290,23 @@ app.get("/report/:reportUri/migrate", reportLimiter, migrateReportUrlHandler);
  * Get the current user's capabilities and limits
  * Uses authLimiter (5000 req/15min per IP)
  */
-app.get("/api/user/limits", authLimiter, getUserLimits);
+app.get(
+  "/api/user/limits",
+  authLimiter,
+  authMiddleware({ tokenLocation: "header" }),
+  getUserLimits as unknown as express.RequestHandler,
+);
 
 /**
  * Update user profile (progressive profiling for monday.com CRM)
  * Uses authLimiter (5000 req/15min per IP)
  */
-app.post("/api/profile/update", authLimiter, updateProfile);
+app.post(
+  "/api/profile/update",
+  authLimiter,
+  authMiddleware({ tokenLocation: "header" }),
+  updateProfile as unknown as express.RequestHandler,
+);
 
 /**
  * Unified report endpoint - handles both Firebase IDs and legacy bucket URLs

--- a/express-server/src/types/context.ts
+++ b/express-server/src/types/context.ts
@@ -42,10 +42,13 @@ export const env = z.object({
   PYSERVER_URL: z
     .string({ required_error: "Missing PYSERVER_URL" })
     .url({ message: "PYSERVER_URL in env should be a valid url" }),
-  NODE_ENV: z.union([z.literal("development"), z.literal("production")], {
-    required_error: "Missing NODE_ENV (production | development)",
-    invalid_type_error: "Invalid input for NODE_ENV",
-  }),
+  NODE_ENV: z.union(
+    [z.literal("development"), z.literal("production"), z.literal("test")],
+    {
+      required_error: "Missing NODE_ENV (production | development | test)",
+      invalid_type_error: "Invalid input for NODE_ENV",
+    },
+  ),
   // REDIS_HOST: z.string({ required_error: "Missing REDIS_HOST" }),
   // REDIS_PORT: z
   //   .string({ required_error: "Missing REDIS_PORT" })


### PR DESCRIPTION
## Summary

- Add `authMiddleware()` with configurable token location (header or body)
- Migrate 4 routes from inline auth to middleware pattern:
  - `/ensure-user` - body-based token
  - `/feedback` - body-based token
  - `/api/user/limits` - header-based token
  - `/api/profile/update` - header-based token
- Add 14 unit tests for the new middleware
- Routes with optional/conditional auth (`/create`, `/auth-events`) unchanged

Closes T3C-896