### PR TITLE
T3C-948: Standardize header-based authentication across all routes

### DIFF
--- a/common/api/index.ts
+++ b/common/api/index.ts
@@ -4,7 +4,6 @@ import * as schema from "../schema";
 export const generateApiRequest = z.object({
   userConfig: schema.llmUserConfig,
   data: schema.dataPayload,
-  firebaseAuthToken: z.string().nullable(),
 });
 
 export type GenerateApiRequest = z.infer<typeof generateApiRequest>;

--- a/express-server/src/middleware.ts
+++ b/express-server/src/middleware.ts
@@ -179,14 +179,6 @@ export const validateOpenAIApiKeyHeader = () => {
 };
 
 /**
- * Configuration options for auth middleware
- */
-interface AuthMiddlewareOptions {
-  /** Where to extract the token from */
-  tokenLocation: "header" | "body";
-}
-
-/**
  * Extracts Bearer token from Authorization header
  * Trims whitespace from the extracted token per RFC 6750
  */
@@ -199,28 +191,16 @@ function extractBearerToken(authHeader: string | undefined): string | null {
 /**
  * Authentication middleware that validates Firebase ID tokens.
  *
- * Supports two token locations:
- * - "header": Extracts from Authorization: Bearer <token>
- * - "body": Extracts from request body firebaseAuthToken field
- *
+ * Extracts token from Authorization: Bearer <token> header.
  * On success, attaches decoded user to req.auth.
  * On failure, sends an error response (AUTH_TOKEN_MISSING or AUTH_TOKEN_INVALID).
  */
-export const authMiddleware = (
-  options: AuthMiddlewareOptions = { tokenLocation: "header" },
-) => {
+export const authMiddleware = () => {
   return async (req: RequestWithLogger, res: Response, next: NextFunction) => {
-    // Extract token based on location
-    const token =
-      options.tokenLocation === "header"
-        ? extractBearerToken(req.headers.authorization)
-        : req.body?.firebaseAuthToken;
+    const token = extractBearerToken(req.headers.authorization);
 
     if (!token) {
-      req.log.warn(
-        { tokenLocation: options.tokenLocation },
-        "Auth token missing",
-      );
+      req.log.warn("Auth token missing");
       return sendErrorByCode(res, ERROR_CODES.AUTH_TOKEN_MISSING, req.log);
     }
 

--- a/express-server/src/routes/__tests__/authEvents.test.ts
+++ b/express-server/src/routes/__tests__/authEvents.test.ts
@@ -38,9 +38,13 @@ describe("Auth Events Route", () => {
   let _mockSendError: any;
   let mockLogger: Logger;
 
-  const createMockRequest = (body: any = {}): RequestWithLogger => {
+  const createMockRequest = (
+    body: any = {},
+    headers: Record<string, string> = {},
+  ): RequestWithLogger => {
     return {
       body,
+      headers,
       log: mockLogger,
     } as RequestWithLogger;
   };
@@ -84,11 +88,13 @@ describe("Auth Events Route", () => {
         name: "Test User",
       };
 
-      const mockRequest = createMockRequest({
-        event: "signin",
-        firebaseAuthToken: "valid-token",
-        clientTimestamp: "2024-01-15T10:30:00.000Z",
-      });
+      const mockRequest = createMockRequest(
+        {
+          event: "signin",
+          clientTimestamp: "2024-01-15T10:30:00.000Z",
+        },
+        { authorization: "Bearer valid-token" },
+      );
       const mockResponse = createMockResponse();
 
       mockVerifyUser.mockResolvedValue(mockDecodedUser);
@@ -154,21 +160,23 @@ describe("Auth Events Route", () => {
       // Act
       await authEvents(mockRequest, mockResponse as Response);
 
-      // Assert - now uses sendErrorByCode with standardized error codes
+      // Assert - now uses sendErrorByCode with AUTH_TOKEN_MISSING
       expect(vi.mocked(sendErrorByCode)).toHaveBeenCalledWith(
         mockResponse,
-        "VALIDATION_ERROR",
+        "AUTH_TOKEN_MISSING",
         mockRequest.log,
       );
     });
 
     it("should handle invalid Firebase tokens", async () => {
       // Arrange
-      const mockRequest = createMockRequest({
-        event: "signin",
-        firebaseAuthToken: "invalid-token",
-        clientTimestamp: "2024-01-15T10:30:00.000Z",
-      });
+      const mockRequest = createMockRequest(
+        {
+          event: "signin",
+          clientTimestamp: "2024-01-15T10:30:00.000Z",
+        },
+        { authorization: "Bearer invalid-token" },
+      );
       const mockResponse = createMockResponse();
 
       const authError = new Error("Invalid token");
@@ -211,11 +219,13 @@ describe("Auth Events Route", () => {
         name: "Monitor User",
       };
 
-      const mockRequest = createMockRequest({
-        event: "signin",
-        firebaseAuthToken: "valid-token",
-        clientTimestamp: "2024-01-15T10:30:00.000Z",
-      });
+      const mockRequest = createMockRequest(
+        {
+          event: "signin",
+          clientTimestamp: "2024-01-15T10:30:00.000Z",
+        },
+        { authorization: "Bearer valid-token" },
+      );
       const mockResponse = createMockResponse();
 
       mockVerifyUser.mockResolvedValue(mockDecodedUser);

--- a/express-server/src/routes/__tests__/create.csv-security.test.ts
+++ b/express-server/src/routes/__tests__/create.csv-security.test.ts
@@ -2,6 +2,7 @@
  * Server-side CSV security validation tests for create route
  */
 
+import type { RequestHandler } from "express";
 import express from "express";
 import request from "supertest";
 import {
@@ -9,6 +10,7 @@ import {
   validateParsedData,
 } from "tttc-common/csv-security";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "../../middleware";
 import create from "../create";
 
 // Mock dependencies
@@ -114,7 +116,7 @@ describe("CSV Security in Create Route", () => {
       next();
     });
 
-    app.post("/create", create);
+    app.post("/create", authMiddleware(), create as unknown as RequestHandler);
   });
 
   beforeEach(() => {
@@ -123,7 +125,6 @@ describe("CSV Security in Create Route", () => {
   });
 
   const createValidRequestBody = (csvData: any[]) => ({
-    firebaseAuthToken: "valid-token",
     userConfig: {
       title: "Test Report",
       description: "Test Description",
@@ -172,6 +173,7 @@ describe("CSV Security in Create Route", () => {
 
     const response = await request(app)
       .post("/create")
+      .set("Authorization", "Bearer valid-token")
       .send(createValidRequestBody(maliciousData))
       .expect(400);
 
@@ -192,6 +194,7 @@ describe("CSV Security in Create Route", () => {
 
     const response = await request(app)
       .post("/create")
+      .set("Authorization", "Bearer valid-token")
       .send(createValidRequestBody(maliciousData))
       .expect(400);
 
@@ -212,6 +215,7 @@ describe("CSV Security in Create Route", () => {
 
     const response = await request(app)
       .post("/create")
+      .set("Authorization", "Bearer valid-token")
       .send(createValidRequestBody(maliciousData))
       .expect(400);
 
@@ -233,6 +237,7 @@ describe("CSV Security in Create Route", () => {
 
     const response = await request(app)
       .post("/create")
+      .set("Authorization", "Bearer valid-token")
       .send(createValidRequestBody(cleanData))
       .expect(200);
     expect(response.body.message).toBe("Request received.");
@@ -251,6 +256,7 @@ describe("CSV Security in Create Route", () => {
 
     const response = await request(app)
       .post("/create")
+      .set("Authorization", "Bearer valid-token")
       .send(createValidRequestBody(dataWithNonStrings))
       .expect(200);
     expect(response.body.message).toBe("Request received.");
@@ -275,6 +281,7 @@ describe("CSV Security in Create Route", () => {
 
     const response = await request(app)
       .post("/create")
+      .set("Authorization", "Bearer valid-token")
       .send(createValidRequestBody(testData))
       .expect(400);
 
@@ -305,6 +312,7 @@ describe("CSV Security in Create Route", () => {
 
     const response = await request(app)
       .post("/create")
+      .set("Authorization", "Bearer valid-token")
       .send(createValidRequestBody(csvData))
       .expect(200);
 

--- a/express-server/src/routes/__tests__/create.data-flow.integration.test.ts
+++ b/express-server/src/routes/__tests__/create.data-flow.integration.test.ts
@@ -5,11 +5,13 @@
  * through server validation to storage, ensuring data integrity at each step.
  */
 
+import type { RequestHandler } from "express";
 import express from "express";
 import request from "supertest";
 import { validateParsedData } from "tttc-common/csv-security";
 import type { SourceRow } from "tttc-common/schema";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { authMiddleware } from "../../middleware";
 import create from "../create";
 
 // Hoist mocks to avoid initialization errors
@@ -104,7 +106,7 @@ describe("End-to-End Data Flow Integration", () => {
       next();
     });
 
-    app.post("/create", create);
+    app.post("/create", authMiddleware(), create as unknown as RequestHandler);
   });
 
   beforeEach(() => {
@@ -140,8 +142,8 @@ describe("End-to-End Data Flow Integration", () => {
 
       const response = await request(app)
         .post("/create")
+        .set("Authorization", "Bearer valid-token")
         .send({
-          firebaseAuthToken: "valid-token",
           userConfig: {
             title: "Test Report",
             description: "Integration test",
@@ -198,8 +200,8 @@ describe("End-to-End Data Flow Integration", () => {
 
       await request(app)
         .post("/create")
+        .set("Authorization", "Bearer valid-token")
         .send({
-          firebaseAuthToken: "valid-token",
           userConfig: {
             title: "Optional Fields Test",
             description: "Test optional field handling",
@@ -261,8 +263,8 @@ describe("End-to-End Data Flow Integration", () => {
 
       await request(app)
         .post("/create")
+        .set("Authorization", "Bearer valid-token")
         .send({
-          firebaseAuthToken: "valid-token",
           userConfig: {
             title: "Validation Test",
             description: "Test validation rejection",
@@ -299,8 +301,8 @@ describe("End-to-End Data Flow Integration", () => {
 
       await request(app)
         .post("/create")
+        .set("Authorization", "Bearer valid-token")
         .send({
-          firebaseAuthToken: "valid-token",
           userConfig: {
             title: "Format Test",
             description: "Test no double-formatting",
@@ -343,8 +345,8 @@ describe("End-to-End Data Flow Integration", () => {
 
       await request(app)
         .post("/create")
+        .set("Authorization", "Bearer valid-token")
         .send({
-          firebaseAuthToken: "valid-token",
           userConfig: {
             title: "Performance Test",
             description: "Large dataset test",
@@ -394,8 +396,8 @@ describe("End-to-End Data Flow Integration", () => {
 
       await request(app)
         .post("/create")
+        .set("Authorization", "Bearer valid-token")
         .send({
-          firebaseAuthToken: "valid-token",
           userConfig: {
             title: "Empty Dataset Test",
             description: "Test empty data handling",
@@ -419,8 +421,8 @@ describe("End-to-End Data Flow Integration", () => {
       // Data that will fail Zod validation - missing required userConfig fields
       await request(app)
         .post("/create")
+        .set("Authorization", "Bearer valid-token")
         .send({
-          firebaseAuthToken: "valid-token",
           userConfig: {
             title: "Invalid Test",
             // Missing required fields

--- a/express-server/src/routes/ensureUser.ts
+++ b/express-server/src/routes/ensureUser.ts
@@ -8,7 +8,7 @@ import { sendErrorByCode } from "./sendError";
 /**
  * Ensures a user document exists in Firestore and syncs new users to Monday.com
  *
- * Requires: authMiddleware({ tokenLocation: "body" })
+ * Requires: authMiddleware()
  */
 export default async function ensureUser(req: RequestWithAuth, res: Response) {
   req.log.info("Ensure user endpoint called");

--- a/express-server/src/routes/feedback.ts
+++ b/express-server/src/routes/feedback.ts
@@ -12,7 +12,7 @@ const feedbackRequest = z.object({
 /**
  * Submit user feedback
  *
- * Requires: authMiddleware({ tokenLocation: "body" })
+ * Requires: authMiddleware()
  */
 export default async function feedback(req: RequestWithAuth, res: Response) {
   req.log.info("Feedback endpoint called");

--- a/express-server/src/routes/profile.ts
+++ b/express-server/src/routes/profile.ts
@@ -45,7 +45,7 @@ const profileUpdateSchema = z.object({
  *
  * Update user profile fields and sync to monday.com
  *
- * Requires: authMiddleware({ tokenLocation: "header" })
+ * Requires: authMiddleware()
  *
  * Request body:
  * {

--- a/express-server/src/routes/user.ts
+++ b/express-server/src/routes/user.ts
@@ -13,7 +13,7 @@ const userLogger = logger.child({ module: "user" });
  * Get the current user's capabilities and limits
  * Returns the user's CSV size limit based on their roles
  *
- * Requires: authMiddleware({ tokenLocation: "header" })
+ * Requires: authMiddleware()
  */
 export async function getUserLimits(
   req: RequestWithAuth,

--- a/express-server/src/server.ts
+++ b/express-server/src/server.ts
@@ -251,7 +251,12 @@ const authLimiter =
  * Creates report
  * Uses reportLimiter (2000 req/15min per IP)
  */
-app.post("/create", reportLimiter, create);
+app.post(
+  "/create",
+  reportLimiter,
+  authMiddleware(),
+  create as unknown as express.RequestHandler,
+);
 
 /**
  * Ensures user document exists in Firestore
@@ -260,7 +265,7 @@ app.post("/create", reportLimiter, create);
 app.post(
   "/ensure-user",
   authLimiter,
-  authMiddleware({ tokenLocation: "body" }),
+  authMiddleware(),
   ensureUser as unknown as express.RequestHandler,
 );
 
@@ -271,7 +276,7 @@ app.post(
 app.post(
   "/feedback",
   authLimiter,
-  authMiddleware({ tokenLocation: "body" }),
+  authMiddleware(),
   feedback as unknown as express.RequestHandler,
 );
 
@@ -293,7 +298,7 @@ app.get("/report/:reportUri/migrate", reportLimiter, migrateReportUrlHandler);
 app.get(
   "/api/user/limits",
   authLimiter,
-  authMiddleware({ tokenLocation: "header" }),
+  authMiddleware(),
   getUserLimits as unknown as express.RequestHandler,
 );
 
@@ -304,7 +309,7 @@ app.get(
 app.post(
   "/api/profile/update",
   authLimiter,
-  authMiddleware({ tokenLocation: "header" }),
+  authMiddleware(),
   updateProfile as unknown as express.RequestHandler,
 );
 

--- a/next-client/src/app/api/feedback/route.ts
+++ b/next-client/src/app/api/feedback/route.ts
@@ -50,10 +50,10 @@ export async function POST(request: Request) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
         text: parsed.data.text,
-        firebaseAuthToken: token,
       }),
     });
 

--- a/next-client/src/app/api/user/ensure/route.ts
+++ b/next-client/src/app/api/user/ensure/route.ts
@@ -34,10 +34,8 @@ export async function POST(request: Request) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({
-        firebaseAuthToken: token,
-      }),
       // Add timeout to prevent hanging requests
       signal: AbortSignal.timeout(10000), // 10 second timeout
     });

--- a/next-client/src/features/submission/actions/SubmitAction.ts
+++ b/next-client/src/features/submission/actions/SubmitAction.ts
@@ -125,7 +125,6 @@ export default async function submitAction(
     const body: GenerateApiRequest = {
       userConfig: config,
       data: dataPayload,
-      firebaseAuthToken,
     };
     submitActionLogger.debug(
       { cruxesEnabled: body.userConfig.cruxesEnabled },
@@ -139,6 +138,7 @@ export default async function submitAction(
       body: JSON.stringify(body),
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Bearer ${firebaseAuthToken}`,
       },
     });
 


### PR DESCRIPTION
## Summary

- Remove `firebaseAuthToken` from API request body schema
- Update all routes to use `Authorization: Bearer <token>` header
- Simplify `authMiddleware` by removing `tokenLocation` option
- Update `/create` to use `authMiddleware()` and `req.auth`
- Update `/auth-events` to read token from Authorization header
- Update client code to send tokens as headers
- Update Next.js API routes to forward Authorization header
- Fix stale JSDoc comments referencing old `tokenLocation` pattern