### PR TITLE
T3C-959: Document .env file format conventions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -111,6 +111,12 @@ Required for LLM processing in pyserver.
 2. Generate API key in API settings
 3. Save the key securely (will be used in environment variables)
 
+## Environment Variable File Format
+
+Use plain `KEY=value` format in `.env` files (no `export` prefix). This ensures compatibility with Docker Compose and dotenv libraries.
+
+To source `.env` files in your shell: `set -a; source .env; set +a`
+
 ## Local Development Setup
 
 ### 1. Install All Dependencies


### PR DESCRIPTION
## Summary

- Documents that `.env` files should use plain `KEY=value` format without `export` prefix
- Explains this ensures compatibility with Docker Compose and dotenv libraries
- Provides the shell workaround for sourcing: `set -a; source .env; set +a`

## Context

Research showed that while some tools (python-dotenv, direnv) tolerate the `export` prefix, Docker Compose explicitly does not support it. Plain format is the lowest common denominator that works everywhere.