### PR TITLE
T3C-975: Simplify common package exports with wildcard pattern

### DIFF
--- a/common/morphisms/index.ts
+++ b/common/morphisms/index.ts
@@ -1,2 +1,2 @@
-export { llmPipelineToSchema } from "./pipeline";
+export { getReportDataObj, llmPipelineToSchema } from "./pipeline";
 export * from "./tree-metrics";

--- a/common/package.json
+++ b/common/package.json
@@ -4,77 +4,17 @@
   "type": "module",
   "description": "Shares common code across monorepo",
   "exports": {
-    "./api": {
-      "types": "./dist/api/index.d.ts",
-      "default": "./dist/api/index.js"
-    },
-    "./apiPyserver": {
-      "types": "./dist/apiPyserver/index.d.ts",
-      "default": "./dist/apiPyserver/index.js"
-    },
-    "./firebase": {
-      "types": "./dist/firebase/index.d.ts",
-      "default": "./dist/firebase/index.js"
-    },
-    "./functional-utils": {
-      "types": "./dist/functional-utils/index.d.ts",
-      "default": "./dist/functional-utils/index.js"
-    },
-    "./logger": {
-      "types": "./dist/logger/index.d.ts",
-      "default": "./dist/logger/index.js"
+    "./*": {
+      "types": "./dist/*/index.d.ts",
+      "default": "./dist/*/index.js"
     },
     "./logger/browser": {
       "types": "./dist/logger/browser.d.ts",
       "default": "./dist/logger/browser.js"
     },
-    "./morphisms": {
-      "types": "./dist/morphisms/index.d.ts",
-      "default": "./dist/morphisms/index.js"
-    },
-    "./morphisms/pipeline": {
-      "types": "./dist/morphisms/pipeline/index.d.ts",
-      "default": "./dist/morphisms/pipeline/index.js"
-    },
-    "./prompts": {
-      "types": "./dist/prompts/index.d.ts",
-      "default": "./dist/prompts/index.js"
-    },
-    "./schema": {
-      "types": "./dist/schema/index.d.ts",
-      "default": "./dist/schema/index.js"
-    },
-    "./utils": {
-      "types": "./dist/utils/index.d.ts",
-      "default": "./dist/utils/index.js"
-    },
-    "./csv-security": {
-      "types": "./dist/csv-security/index.d.ts",
-      "default": "./dist/csv-security/index.js"
-    },
-    "./csv-validation": {
-      "types": "./dist/csv-validation/index.d.ts",
-      "default": "./dist/csv-validation/index.js"
-    },
-    "./permissions": {
-      "types": "./dist/permissions/index.d.ts",
-      "default": "./dist/permissions/index.js"
-    },
-    "./analytics": {
-      "types": "./dist/analytics/index.d.ts",
-      "default": "./dist/analytics/index.js"
-    },
-    "./feature-flags": {
-      "types": "./dist/feature-flags/index.d.ts",
-      "default": "./dist/feature-flags/index.js"
-    },
     "./evaluations/*/scorers": {
       "types": "./dist/evaluations/*/scorers.d.ts",
       "default": "./dist/evaluations/*/scorers.js"
-    },
-    "./errors": {
-      "types": "./dist/errors/index.d.ts",
-      "default": "./dist/errors/index.js"
     }
   },
   "engines": {

--- a/next-client/__tests__/data/testData.ts
+++ b/next-client/__tests__/data/testData.ts
@@ -1,4 +1,4 @@
-import { getReportDataObj } from "tttc-common/morphisms/pipeline";
+import { getReportDataObj } from "tttc-common/morphisms";
 import * as schema from "tttc-common/schema";
 import jsonData from "./aiAssemblies.json";
 

--- a/next-client/src/lib/report/handleResponseData.ts
+++ b/next-client/src/lib/report/handleResponseData.ts
@@ -1,6 +1,6 @@
 import pRetry from "p-retry";
 import * as api from "tttc-common/api";
-import { getReportDataObj } from "tttc-common/morphisms/pipeline";
+import { getReportDataObj } from "tttc-common/morphisms";
 import * as schema from "tttc-common/schema";
 import { z } from "zod";
 

--- a/next-client/stories/data/dummyData.ts
+++ b/next-client/stories/data/dummyData.ts
@@ -1,4 +1,4 @@
-import { getReportDataObj } from "tttc-common/morphisms/pipeline";
+import { getReportDataObj } from "tttc-common/morphisms";
 import * as schema from "tttc-common/schema";
 import jsonData from "./healMichigan.json";
 

--- a/utils/src/functions/turboToSchema.ts
+++ b/utils/src/functions/turboToSchema.ts
@@ -1,4 +1,4 @@
-import { llmPipelineToSchema } from "tttc-common/morphisms/pipeline";
+import { llmPipelineToSchema } from "tttc-common/morphisms";
 import * as schema from "tttc-common/schema";
 import { v4 } from "uuid";
 import { z } from "zod";


### PR DESCRIPTION
## Summary

- Replace 17 explicit export entries with a single wildcard pattern `./*` (80% reduction)
- Re-export `getReportDataObj` from `morphisms/index.ts` to eliminate `morphisms/pipeline` export
- Keep explicit entries only for edge cases: `logger/browser` and `evaluations/*/scorers`

Adding new modules is now trivial: just create `common/my-module/index.ts`