### PR TITLE
T3C-993: Remove empty credentials directory from express-server

### DIFF
--- a/express-server/credentials/.keep
+++ b/express-server/credentials/.keep
@@ -1,1 +1,0 @@
-just here so git tracks dir


### PR DESCRIPTION
## Summary

- Removes the `express-server/credentials/` directory which only contained a `.keep` file
- Credentials are now managed via environment variables and Secret Manager

## ⚠️ Note for Developers

If you have local credential files in `express-server/credentials/`, please migrate them to environment variables. See `DEVELOPMENT.md` for setup instructions.

Closes T3C-993