### PR TITLE
T3C-1013: Simplify tree-metrics with explicit functions

### DIFF
--- a/common/morphisms/tests/tree-metrics.test.mts
+++ b/common/morphisms/tests/tree-metrics.test.mts
@@ -1,49 +1,154 @@
 import { describe, expect, test } from "vitest";
-import * as schema from "../../schema";
-import { getNPeople } from "../tree-metrics.js";
+import type * as schema from "../../schema";
+import {
+  getNClaims,
+  getNPeopleFromClaims,
+  getNPeopleFromReport,
+  getNPeopleFromSubtopics,
+  getNPeopleFromTopics,
+  getQuotes,
+} from "../tree-metrics.js";
 
 const data = require("./data/getNPeople.json");
 
-function isJsonString(str: string) {
-  try {
-    JSON.stringify(str);
-  } catch (_e) {
-    return false;
-  }
-  return true;
-}
+describe("getNPeopleFromReport", () => {
+  const pipelineOutput = data as { data: [unknown, schema.ReportDataObj] };
+  const report = pipelineOutput.data[1];
 
-describe("Test to make sure test data is valid", () => {
-  test("Is valid json", () => {
-    expect(isJsonString(data)).true;
-  });
-
-  test("Is report data", () => {
-    expect(schema.pipelineOutput.safeParse(data).success).true;
+  test("gets correct count from report", () => {
+    expect(getNPeopleFromReport(report)).toBe(8);
   });
 });
 
-describe("getNPeople", () => {
-  const pipelineOutput = schema.pipelineOutput.parse(data);
+describe("getNPeopleFromTopics", () => {
+  const pipelineOutput = data as { data: [unknown, schema.ReportDataObj] };
   const report = pipelineOutput.data[1];
   const topics = report.topics;
-  const subtopics = topics.flatMap((t) => t.subtopics);
 
-  test("Gets correct number of people from report", () => {
-    expect(getNPeople(report)).toBe(8);
+  test("gets correct count from all topics", () => {
+    expect(getNPeopleFromTopics(topics)).toBe(8);
   });
 
-  test("Gets correct number of people from topics", () => {
-    expect(getNPeople([topics[0]])).toBe(5);
-    expect(getNPeople([topics[1]])).toBe(3);
+  test("gets correct count from individual topics", () => {
+    expect(getNPeopleFromTopics([topics[0]])).toBe(5);
+    expect(getNPeopleFromTopics([topics[1]])).toBe(3);
   });
 
-  test("Gets correct number of people from subtopics", () => {
-    expect(getNPeople([subtopics[0]])).toBe(3);
-    expect(getNPeople([subtopics[1]])).toBe(2);
-    expect(getNPeople([subtopics[2]])).toBe(3);
-    expect(getNPeople([subtopics[3]])).toBe(0);
+  test("returns 0 for empty array", () => {
+    expect(getNPeopleFromTopics([])).toBe(0);
+  });
+});
+
+describe("getNPeopleFromSubtopics", () => {
+  const pipelineOutput = data as { data: [unknown, schema.ReportDataObj] };
+  const report = pipelineOutput.data[1];
+  const subtopics = report.topics.flatMap((t) => t.subtopics);
+
+  test("gets correct count from individual subtopics", () => {
+    expect(getNPeopleFromSubtopics([subtopics[0]])).toBe(3);
+    expect(getNPeopleFromSubtopics([subtopics[1]])).toBe(2);
+    expect(getNPeopleFromSubtopics([subtopics[2]])).toBe(3);
+    expect(getNPeopleFromSubtopics([subtopics[3]])).toBe(0);
   });
 
-  // The rest is trivial
+  test("returns 0 for empty array", () => {
+    expect(getNPeopleFromSubtopics([])).toBe(0);
+  });
+});
+
+describe("getNPeopleFromClaims", () => {
+  const pipelineOutput = data as { data: [unknown, schema.ReportDataObj] };
+  const report = pipelineOutput.data[1];
+  const subtopics = report.topics.flatMap((t) => t.subtopics);
+
+  test("gets correct count from claims", () => {
+    const firstSubtopicClaims = subtopics[0].claims;
+    expect(getNPeopleFromClaims(firstSubtopicClaims)).toBe(3);
+  });
+
+  test("handles claims with similarClaims", () => {
+    const allClaims = subtopics.flatMap((s) => s.claims);
+    const reportCount = getNPeopleFromReport(report);
+    const claimsCount = getNPeopleFromClaims(allClaims);
+    expect(claimsCount).toBe(reportCount);
+  });
+
+  test("returns 0 for empty array", () => {
+    expect(getNPeopleFromClaims([])).toBe(0);
+  });
+
+  test("counts unique interviews only (deduplication)", () => {
+    const allClaims = subtopics.flatMap((s) => s.claims);
+    const totalPeople = getNPeopleFromClaims(allClaims);
+    const sumOfSubtopics = subtopics.reduce(
+      (sum, st) => sum + getNPeopleFromSubtopics([st]),
+      0,
+    );
+    expect(totalPeople).toBeLessThanOrEqual(sumOfSubtopics);
+  });
+});
+
+describe("getNClaims", () => {
+  const pipelineOutput = data as { data: [unknown, schema.ReportDataObj] };
+  const report = pipelineOutput.data[1];
+  const subtopics = report.topics.flatMap((t) => t.subtopics);
+
+  test("returns total claim count from subtopics", () => {
+    const totalClaims = subtopics.flatMap((s) => s.claims).length;
+    expect(getNClaims(subtopics)).toBe(totalClaims);
+  });
+
+  test("returns 0 for empty subtopic array", () => {
+    expect(getNClaims([])).toBe(0);
+  });
+
+  test("returns 0 for subtopics with no claims", () => {
+    const emptySubtopic: schema.Subtopic = {
+      id: "empty",
+      title: "Empty",
+      description: "No claims",
+      claims: [],
+    };
+    expect(getNClaims([emptySubtopic])).toBe(0);
+  });
+});
+
+describe("getQuotes", () => {
+  const pipelineOutput = data as { data: [unknown, schema.ReportDataObj] };
+  const report = pipelineOutput.data[1];
+  const claims = report.topics.flatMap((t) =>
+    t.subtopics.flatMap((s) => s.claims),
+  );
+
+  test("returns quotes from claim", () => {
+    const claimWithQuotes = claims.find((c) => c.quotes.length > 0);
+    if (claimWithQuotes) {
+      const quotes = getQuotes(claimWithQuotes);
+      expect(quotes.length).toBeGreaterThanOrEqual(
+        claimWithQuotes.quotes.length,
+      );
+    }
+  });
+
+  test("includes quotes from similarClaims", () => {
+    const claimWithSimilar = claims.find((c) => c.similarClaims.length > 0);
+    if (claimWithSimilar) {
+      const quotes = getQuotes(claimWithSimilar);
+      const directQuotes = claimWithSimilar.quotes.length;
+      const similarQuotes = claimWithSimilar.similarClaims.flatMap(
+        (sc) => sc.quotes,
+      ).length;
+      expect(quotes.length).toBe(directQuotes + similarQuotes);
+    }
+  });
+
+  test("returns empty array for claim with no quotes", () => {
+    const emptyQuotesClaim: schema.Claim = {
+      id: "c1",
+      title: "Test",
+      quotes: [],
+      similarClaims: [],
+    };
+    expect(getQuotes(emptyQuotesClaim)).toEqual([]);
+  });
 });

--- a/next-client/src/components/report/Report.stories.tsx
+++ b/next-client/src/components/report/Report.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { getNPeople } from "tttc-common/morphisms";
+import { getNPeopleFromTopics } from "tttc-common/morphisms";
 import * as schema from "tttc-common/schema";
 import { reportData } from "../../../stories/data/dummyData";
 import jsonData from "../../../stories/data/healMichigan.json";
@@ -73,7 +73,7 @@ export const Title = () => (
         theme.subtopics.flatMap((topic) => topic.claims),
       ).length
     }
-    nPeople={getNPeople(baseProps.topics)}
+    nPeople={getNPeopleFromTopics(baseProps.topics)}
     nThemes={baseProps.topics.length}
     nTopics={baseProps.topics.flatMap((theme) => theme.subtopics).length}
     dateStr={baseProps.date}

--- a/next-client/src/components/report/components/ReportHeader.tsx
+++ b/next-client/src/components/report/components/ReportHeader.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
-import { getNPeople } from "tttc-common/morphisms";
+import {
+  getNPeopleFromClaims,
+  getNPeopleFromSubtopics,
+} from "tttc-common/morphisms";
 import type * as schema from "tttc-common/schema";
 import Icons from "@/assets/icons";
 import {
@@ -43,7 +46,7 @@ export function ReportHeader({
 }) {
   const topics = themes.flatMap((theme) => theme.subtopics);
   const claims = topics.flatMap((topic) => topic.claims);
-  const nPeople = getNPeople(claims);
+  const nPeople = getNPeopleFromClaims(claims);
   const dateStr = date;
   return (
     <CardContent className="print:pb-0" data-report-header>
@@ -204,15 +207,15 @@ export function ReportSummary({
 export function ReportOverview({ topics }: { topics: schema.Topic[] }) {
   const getBarChartEntries = (topics: schema.Topic[]): BarChartItemType[] => {
     const largestN = topics.reduce((accum, curr) => {
-      const nClaims = getNPeople(curr.subtopics);
+      const nClaims = getNPeopleFromSubtopics(curr.subtopics);
       return Math.max(nClaims, accum);
     }, 0);
 
     return topics.map((topic) => ({
       id: topic.id,
       title: topic.title,
-      percentFill: getNPeople(topic.subtopics) / largestN,
-      subtitle: `${getNPeople(topic.subtopics)} people`,
+      percentFill: getNPeopleFromSubtopics(topic.subtopics) / largestN,
+      subtitle: `${getNPeopleFromSubtopics(topic.subtopics)} people`,
       color: topic.topicColor,
     }));
   };

--- a/next-client/src/components/report/hooks/useReportState/utils.ts
+++ b/next-client/src/components/report/hooks/useReportState/utils.ts
@@ -1,4 +1,7 @@
-import { getNPeople } from "tttc-common/morphisms";
+import {
+  getNPeopleFromSubtopics,
+  getNPeopleFromTopics,
+} from "tttc-common/morphisms";
 import type * as schema from "tttc-common/schema";
 import { defaultSubtopicPagination, defaultTopicPagination } from "./consts";
 import type { ClaimNode, ReportState, SubtopicNode, TopicNode } from "./types";
@@ -13,7 +16,9 @@ import type { ClaimNode, ReportState, SubtopicNode, TopicNode } from "./types";
 export const stateBuilder = (topics: schema.Topic[]): ReportState => ({
   children: topics
     .map(makeTopicNode)
-    .sort((a, b) => getNPeople([b.data]) - getNPeople([a.data])),
+    .sort(
+      (a, b) => getNPeopleFromTopics([b.data]) - getNPeopleFromTopics([a.data]),
+    ),
   focusedId: null,
   error: null,
 });
@@ -26,7 +31,10 @@ const makeTopicNode = (topic: schema.Topic): TopicNode => ({
   pagination: Math.min(topic.subtopics.length - 1, defaultTopicPagination),
   children: topic.subtopics
     .map(makeSubtopicNode)
-    .sort((a, b) => getNPeople([b.data]) - getNPeople([a.data])),
+    .sort(
+      (a, b) =>
+        getNPeopleFromSubtopics([b.data]) - getNPeopleFromSubtopics([a.data]),
+    ),
 });
 
 const makeSubtopicNode = (subtopic: schema.Subtopic): SubtopicNode => ({

--- a/next-client/src/components/subtopic/Subtopic.tsx
+++ b/next-client/src/components/subtopic/Subtopic.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useContext, useMemo } from "react";
 import { mergeRefs } from "react-merge-refs";
-import { getNPeople } from "tttc-common/morphisms";
+import { getNPeopleFromClaims } from "tttc-common/morphisms";
 import type * as schema from "tttc-common/schema";
 import Icons from "@/assets/icons";
 import { ControversyIcon } from "@/assets/icons/ControversyIcons";
@@ -153,7 +153,7 @@ export function SubtopicSummary({
       <SubtopicHeader
         title={title}
         numClaims={claims.length}
-        numPeople={getNPeople(claims)}
+        numPeople={getNPeopleFromClaims(claims)}
       />
       <div className="print:hidden">
         <PointGraphic claims={claims} />

--- a/next-client/src/components/topic/Topic.tsx
+++ b/next-client/src/components/topic/Topic.tsx
@@ -3,7 +3,11 @@
 import type React from "react";
 import { createContext, forwardRef, useContext } from "react";
 import { mergeRefs } from "react-merge-refs";
-import { getNClaims, getNPeople } from "tttc-common/morphisms";
+import {
+  getNClaims,
+  getNPeopleFromClaims,
+  getNPeopleFromSubtopics,
+} from "tttc-common/morphisms";
 import type * as schema from "tttc-common/schema";
 import Icons from "@/assets/icons";
 import { ControversyIndicator } from "@/components/controversy";
@@ -107,7 +111,8 @@ export function TopicHeader({ button }: { button?: React.ReactNode }) {
           <Icons.Claim className="h-4 w-4" />
         </div>
         <p className="p2 text-muted-foreground flex gap-2 items-center ">
-          {getNClaims(subtopics)} claims by {getNPeople(subtopics)} people
+          {getNClaims(subtopics)} claims by {getNPeopleFromSubtopics(subtopics)}{" "}
+          people
         </p>
         {shouldShowControversy && controversyScore !== undefined && (
           <ControversyIndicator score={controversyScore} showLabel={true} />
@@ -278,7 +283,7 @@ export function SubtopicListItem({
           <SubtopicHeader
             title={subtopic.title}
             numClaims={subtopic.claims.length}
-            numPeople={getNPeople(subtopic.claims)}
+            numPeople={getNPeopleFromClaims(subtopic.claims)}
           />
           <p className="text-muted-foreground line-clamp-4">
             {subtopic.description}


### PR DESCRIPTION
## Summary

- Replaced polymorphic `getNPeople` with 4 explicit type-specific functions
- Removed complex `chainMatch` pattern that used Zod for runtime type detection
- Updated 6 component files to use the new explicit API

## Changes

**New API:**
- `getNPeopleFromClaims(claims: Claim[])`
- `getNPeopleFromSubtopics(subtopics: Subtopic[])`
- `getNPeopleFromTopics(topics: Topic[])`
- `getNPeopleFromReport(report: ReportDataObj)`

**Metrics:**
| Metric | Before | After |
|--------|--------|-------|
| CodeScene score | 9.68 | 10.00 |
| Cyclomatic complexity | 10 | 1-3 |
| Runtime type checks | Zod | None |

Closes T3C-1013