### PR TITLE
T3C-971: Replace z.union with ternary for NODE_ENV validation

### DIFF
--- a/next-client/src/lib/firebase/firestoreClient.ts
+++ b/next-client/src/lib/firebase/firestoreClient.ts
@@ -18,12 +18,10 @@ import {
   useGetCollectionName,
 } from "tttc-common/firebase";
 import { failure, type Result, success } from "tttc-common/functional-utils";
-import { z } from "zod";
 import type { FeedbackRequest } from "../types/clientRoutes";
 
-const NODE_ENV = z
-  .union([z.literal("development"), z.literal("production")])
-  .parse(process.env.NODE_ENV);
+const NODE_ENV =
+  process.env.NODE_ENV === "production" ? "production" : "development";
 // biome-ignore lint/correctness/useHookAtTopLevel: useGetCollectionName is a factory function, not a React hook despite its name
 const getCollectionName = useGetCollectionName(NODE_ENV);
 


### PR DESCRIPTION
## Summary

- Replaces `z.union([z.literal("development"), z.literal("production")])` with a simple ternary check
- Fixes compatibility with vitest which sets `NODE_ENV=test`
- Removes unused zod import

Closes T3C-971