### PR TITLE
T3C-1015: Migrate from deprecated sendError() to sendErrorByCode()

### DIFF
--- a/express-server/src/routes/__tests__/authEvents.test.ts
+++ b/express-server/src/routes/__tests__/authEvents.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { verifyUser } from "../../Firebase";
 import type { RequestWithLogger } from "../../types/request";
 import authEvents from "../authEvents";
-import { sendError, sendErrorByCode } from "../sendError.js";
+import { sendErrorByCode } from "../sendError.js";
 
 // Mock Firebase functions
 vi.mock("../../Firebase", () => ({
@@ -13,7 +13,6 @@ vi.mock("../../Firebase", () => ({
 
 // Mock sendError utilities
 vi.mock("../sendError.js", () => ({
-  sendError: vi.fn(),
   sendErrorByCode: vi.fn(),
 }));
 
@@ -35,7 +34,6 @@ vi.mock("tttc-common/logger", () => {
 
 describe("Auth Events Route", () => {
   let mockVerifyUser: any;
-  let _mockSendError: any;
   let mockLogger: Logger;
 
   const createMockRequest = (
@@ -60,7 +58,6 @@ describe("Auth Events Route", () => {
     vi.clearAllMocks();
 
     mockVerifyUser = vi.mocked(verifyUser);
-    _mockSendError = vi.mocked(sendError);
 
     mockLogger = {
       info: vi.fn(),

--- a/express-server/src/routes/__tests__/report.test.ts
+++ b/express-server/src/routes/__tests__/report.test.ts
@@ -6,7 +6,7 @@ import * as Firebase from "../../Firebase";
 import { Bucket } from "../../storage";
 import type { RequestWithLogger } from "../../types/request";
 import { getUnifiedReportHandler, migrateReportUrlHandler } from "../report";
-import { sendError, sendErrorByCode } from "../sendError";
+import { sendErrorByCode } from "../sendError";
 
 const testReportId = "A1B2C3D4E5F6G7H8I9J0";
 
@@ -140,7 +140,6 @@ vi.mock("tttc-common/utils", () => ({
 
 // Mock sendError functions
 vi.mock("../sendError", () => ({
-  sendError: vi.fn(),
   sendErrorByCode: vi.fn(),
 }));
 
@@ -200,18 +199,6 @@ describe("Report Routes", () => {
     mockReq = createMockRequest();
     mockRes = createMockResponse();
     vi.clearAllMocks();
-
-    // Setup sendError mock to behave like the real function
-    vi.mocked(sendError).mockImplementation(
-      (res, status, message, errorCode) => {
-        res.status(status).json({
-          error: {
-            message,
-            ...(errorCode ? { code: errorCode } : {}),
-          },
-        });
-      },
-    );
 
     // Setup sendErrorByCode mock to behave like the real function
     vi.mocked(sendErrorByCode).mockImplementation((res, code) => {

--- a/express-server/src/routes/profile.ts
+++ b/express-server/src/routes/profile.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import * as firebase from "../Firebase";
 import { createMondayItem } from "../services/monday";
 import type { RequestWithAuth } from "../types/request";
-import { sendError } from "./sendError";
+import { sendErrorByCode } from "./sendError";
 
 const profileLogger = logger.child({ module: "profile" });
 
@@ -123,21 +123,11 @@ export async function updateProfile(req: RequestWithAuth, res: Response) {
   } catch (error) {
     if (error instanceof z.ZodError) {
       profileLogger.warn({ error: error.errors }, "Profile validation failed");
-      sendError(
-        res,
-        400,
-        `Invalid profile data: ${error.errors.map((e) => e.message).join(", ")}`,
-        "ValidationError",
-      );
+      sendErrorByCode(res, "VALIDATION_ERROR", profileLogger);
       return;
     }
 
     profileLogger.error({ error }, "Profile update failed");
-    sendError(
-      res,
-      500,
-      error instanceof Error ? error.message : "Failed to update profile",
-      "ProfileUpdateError",
-    );
+    sendErrorByCode(res, "INTERNAL_ERROR", profileLogger);
   }
 }

--- a/express-server/src/routes/sendError.ts
+++ b/express-server/src/routes/sendError.ts
@@ -7,40 +7,6 @@ import {
 } from "tttc-common/errors";
 
 /**
- * Sends a consistent JSON error response.
- * @param res Express response object
- * @param status HTTP status code
- * @param message Error message
- * @param errorCode Optional error code
- * @param logger Optional logger for error tracking
- * @param requestId Optional request ID for log correlation
- * @deprecated Use sendErrorByCode() for new code to ensure consistent error messages
- */
-export function sendError(
-  res: Response,
-  status: number,
-  message: string,
-  errorCode?: string,
-  logger?: Logger,
-  requestId?: string,
-) {
-  if (logger) {
-    logger.warn(
-      { status, message, errorCode, requestId },
-      "Sending error response",
-    );
-  }
-
-  res.status(status).json({
-    error: {
-      message,
-      ...(errorCode ? { code: errorCode } : {}),
-      ...(requestId ? { requestId } : {}),
-    },
-  });
-}
-
-/**
  * Sends an error response using standardized error codes.
  * Automatically uses the correct HTTP status code and user-friendly message.
  * @param res Express response object


### PR DESCRIPTION
## Summary

- Update profile.ts to use `sendErrorByCode()` with standardized error codes (`VALIDATION_ERROR`, `INTERNAL_ERROR`)
- Remove deprecated `sendError()` function from sendError.ts
- Update test mocks to no longer reference `sendError()`

Closes T3C-1015