### PR TITLE
T3C-1021: Remove unnecessary use client from LandingHero

### DIFF
--- a/next-client/src/assets/hero/LandingHero.tsx
+++ b/next-client/src/assets/hero/LandingHero.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Image from "next/image";
 import heroImage from "@/../public/images/t3c-product-desktop-mobile.png";
 import { cn } from "@/lib/utils/shadcn";


### PR DESCRIPTION
## Summary

- Removes unnecessary `"use client"` directive from `LandingHero.tsx`
- This component only uses `next/image` with a static import and doesn't require client-side interactivity