### PR TITLE
T3C-37: Fix navigation hiccup when clicking "Generate report"

### DIFF
--- a/next-client/src/app/report/[uri]/loading.tsx
+++ b/next-client/src/app/report/[uri]/loading.tsx
@@ -1,0 +1,11 @@
+import { Progress } from "@/components/elements";
+import { Col } from "@/components/layout";
+
+export default function ReportLoading() {
+  return (
+    <Col className="w-full h-full flex-grow items-center justify-center">
+      <Progress value={0} className="w-[60%]" />
+      <p>Your report is queued...</p>
+    </Col>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `loading.tsx` for report route to show progress bar immediately during navigation (Next.js App Router pattern)
- Keep `FormLoading` visible when `response.status` is `"success"` to prevent form flash-back before navigation completes
- Add 5-second timeout fallback with manual link in case navigation stalls

Fixes the jarring visual transition where clicking "Generate report" would briefly flash back to the create form before showing the progress bar.