### PR TITLE
T3C-1030: Move Perspective API key from URL query string to header

### DIFF
--- a/express-server/src/lib/perspective-api.ts
+++ b/express-server/src/lib/perspective-api.ts
@@ -266,9 +266,12 @@ async function callPerspectiveApi(
     languages: ["en"], // Bridging attributes are English-only
   };
 
-  const response = await fetch(`${PERSPECTIVE_API_URL}?key=${apiKey}`, {
+  const response = await fetch(PERSPECTIVE_API_URL, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "X-goog-api-key": apiKey,
+    },
     body: JSON.stringify(requestBody),
   });
 


### PR DESCRIPTION
## Summary

- Move Perspective API key from URL query string (`?key=`) to `X-goog-api-key` header
- Follows [Google's recommended approach](https://docs.cloud.google.com/docs/authentication/api-keys-use) for API key authentication

## Why

API keys in URLs can be:
- Logged by proxies, load balancers, and HTTP access logs
- Exposed in Referer headers to third-party resources
- Visible in browser history