### PR TITLE
T3C-1024: Create shared vitest configuration

### DIFF
--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -35,5 +35,5 @@
     "./types/*",
     "./utils/*"
   ],
-  "exclude": ["dist/", "**/*/*.test.*"]
+  "exclude": ["dist/", "**/*/*.test.*", "vitest.config.ts"]
 }

--- a/common/vitest.config.ts
+++ b/common/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.shared";
+
+/**
+ * Common package vitest configuration.
+ *
+ * Uses default shared settings. No special aliases needed since
+ * this IS the common package.
+ */
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      // Project name for workspace identification
+      name: "common",
+    },
+  }),
+);

--- a/express-server/vitest.config.ts
+++ b/express-server/vitest.config.ts
@@ -1,17 +1,33 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.shared";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export default defineConfig({
-  test: {
-    testTimeout: 1000000,
-  },
-  resolve: {
-    alias: {
-      // Point to source files for better mocking support in tests
-      "tttc-common": path.resolve(__dirname, "../common"),
+/**
+ * Express server vitest configuration.
+ *
+ * Extended timeout for integration tests that interact with:
+ * - Firebase
+ * - Google Cloud Storage
+ * - Redis
+ * - External APIs (Perspective, OpenAI)
+ */
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      name: "express-server",
+      // Extended timeout for integration tests with external services
+      testTimeout: 1000000,
     },
-  },
-});
+    resolve: {
+      alias: {
+        // Point to source files for better mocking support in tests
+        // Enables: vi.mock('tttc-common/schema', () => ...)
+        "tttc-common": path.resolve(__dirname, "../common"),
+      },
+    },
+  }),
+);

--- a/next-client/tsconfig.json
+++ b/next-client/tsconfig.json
@@ -32,8 +32,12 @@
     ".next/types/**/*.ts",
     "./dist/types/**/*.ts",
     "env-check.js",
-    ".storybook/miscStories/Typography.stories.tsx",
-    "vitest.config.mts"
+    ".storybook/miscStories/Typography.stories.tsx"
   ],
-  "exclude": ["node_modules", "**/*/*.test.*", "**/*/*.stories.*"]
+  "exclude": [
+    "node_modules",
+    "**/*/*.test.*",
+    "**/*/*.stories.*",
+    "vitest.config.mts"
+  ]
 }

--- a/next-client/vitest.config.mts
+++ b/next-client/vitest.config.mts
@@ -1,23 +1,44 @@
-import path, { resolve } from "node:path";
-import { defineConfig } from "vitest/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.shared";
 
-export default defineConfig({
-  esbuild: {
-    jsx: "automatic",
-  },
-  test: {
-    environment: "jsdom",
-    setupFiles: ["./__tests__/setup/vitest.setup.ts"],
-    alias: [{ find: "@src", replacement: resolve(__dirname, "./src") }],
-    include: ["**/*.test.t*"],
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      stories: path.resolve(__dirname, "./stories"),
-      __tests__: path.resolve(__dirname, "./__tests__"),
-      // Point to source files for better mocking support in tests
-      "tttc-common": path.resolve(__dirname, "../common"),
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Next.js client vitest configuration.
+ *
+ * Uses jsdom environment for React component testing.
+ * Custom setup file extends expect with @testing-library/jest-dom matchers.
+ */
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    esbuild: {
+      // Required for JSX in test files
+      jsx: "automatic",
     },
-  },
-});
+    test: {
+      name: "next-client",
+      // Browser-like environment for React component testing
+      environment: "jsdom",
+      // Extends expect with jest-dom matchers and custom matchers
+      setupFiles: ["./__tests__/setup/vitest.setup.ts"],
+      // Override include to support both .ts and .tsx (matches existing pattern)
+      include: ["**/*.test.t*"],
+      // Additional test-specific alias
+      alias: [{ find: "@src", replacement: path.resolve(__dirname, "./src") }],
+    },
+    resolve: {
+      alias: {
+        // Next.js path alias
+        "@": path.resolve(__dirname, "./src"),
+        // Test helper paths
+        stories: path.resolve(__dirname, "./stories"),
+        __tests__: path.resolve(__dirname, "./__tests__"),
+        // Common package source for mocking
+        "tttc-common": path.resolve(__dirname, "../common"),
+      },
+    },
+  }),
+);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:common": "pnpm -F tttc-common run test",
     "test:server": "pnpm -F express-server run test",
     "test:client": "pnpm -F next-client run test",
+    "test:workspace": "vitest",
     "prepare": "husky",
     "quality:check": "cs delta --staged",
     "codescene:local": "cs delta --staged",

--- a/pipeline-worker/vitest.config.ts
+++ b/pipeline-worker/vitest.config.ts
@@ -1,13 +1,33 @@
 import path from "node:path";
-import { defineConfig } from "vitest/config";
-export default defineConfig({
-  test: {
-    testTimeout: 1000000,
-  },
-  resolve: {
-    alias: {
-      "tttc-common": path.resolve(__dirname, "../common/dist"),
-      common: path.resolve(__dirname, "../common"),
+import { fileURLToPath } from "node:url";
+import { defineConfig, mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.shared";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Pipeline worker vitest configuration.
+ *
+ * Extended timeout for pipeline processing tests that may involve:
+ * - Large data transformations
+ * - LLM API calls (in integration tests)
+ * - Pub/Sub message processing
+ */
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      name: "pipeline-worker",
+      // Extended timeout for pipeline processing tests
+      testTimeout: 1000000,
     },
-  },
-});
+    resolve: {
+      alias: {
+        // Point to source files for better mocking support
+        "tttc-common": path.resolve(__dirname, "../common"),
+        // Some code imports via 'common/*' pattern
+        common: path.resolve(__dirname, "../common"),
+      },
+    },
+  }),
+);

--- a/utils/vitest.config.ts
+++ b/utils/vitest.config.ts
@@ -1,7 +1,26 @@
-import { defineConfig } from "vitest/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, mergeConfig } from "vitest/config";
+import sharedConfig from "../vitest.shared";
 
-export default defineConfig({
-  test: {
-    testTimeout: 30000,
-  },
-});
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Utils package vitest configuration.
+ *
+ * Uses default shared timeout (30s) which is appropriate for
+ * utility script testing.
+ */
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      name: "utils",
+    },
+    resolve: {
+      alias: {
+        "tttc-common": path.resolve(__dirname, "../common"),
+      },
+    },
+  }),
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Root vitest configuration for running all tests from the monorepo root.
+ *
+ * Usage:
+ *   pnpm test:workspace        # Run all tests across all projects
+ *   pnpm vitest --project common   # Run tests for specific project
+ *
+ * Note: Most developers will continue using `pnpm test` which uses turbo.
+ * This root config enables unified test runs when needed.
+ */
+export default defineConfig({
+  test: {
+    // Reference each package's vitest config as a project
+    projects: [
+      "common/vitest.config.ts",
+      "express-server/vitest.config.ts",
+      "pipeline-worker/vitest.config.ts",
+      "next-client/vitest.config.mts",
+      "utils/vitest.config.ts",
+    ],
+  },
+});

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Shared vitest configuration for all packages in the monorepo.
+ *
+ * Each package's vitest.config.ts should import and extend this config:
+ *   import { mergeConfig } from 'vitest/config';
+ *   import sharedConfig from '../vitest.shared';
+ *   export default mergeConfig(sharedConfig, defineConfig({ ... }));
+ */
+export default defineConfig({
+  test: {
+    // Reasonable default timeout (packages with integration tests can override)
+    testTimeout: 30000,
+
+    // Consistent test pattern across all packages
+    include: ["**/*.test.{ts,tsx}"],
+
+    // Exclude build artifacts and node_modules
+    exclude: ["**/node_modules/**", "**/dist/**", "**/.next/**"],
+
+    // Use forks for better test isolation
+    pool: "forks",
+
+    // Don't fail if a package has no tests yet
+    passWithNoTests: true,
+
+    // Basic coverage configuration (can be extended per-package)
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/*.test.*",
+        "**/__tests__/**",
+        "**/test-utils/**", // Ready for T3C-1025
+        "**/stories/**",
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Add `vitest.shared.ts` with common defaults (30s timeout, coverage config, forks pool)
- Add root `vitest.config.ts` with `test.projects` for workspace runs
- Create `common/vitest.config.ts` (was missing, now extends shared)
- Update all package configs to use `mergeConfig` with shared base
- Fix pipeline-worker `__dirname` bug (was missing `import.meta.url` setup)
- Add `test:workspace` script for unified test runs from root
- Document package-specific overrides inline (timeouts, jsdom, etc.)

Closes T3C-1024