### PR TITLE
T3C-966: Block oversized comments with soft warning at 5K chars

### DIFF
--- a/next-client/src/components/create/components/FormSections.tsx
+++ b/next-client/src/components/create/components/FormSections.tsx
@@ -242,6 +242,17 @@ export function FormDataInput({
             : `File is too large - ${formatBytes(userSizeLimit)} limit`;
         setInlineError(errorMessage);
         handleReset(inputRef);
+      } else if (result.error.tag === "Oversized Comments") {
+        // Oversized comments - show inline error with details
+        const { count, maxLength, affectedIds } = result.error;
+        const MAX_ID_DISPLAY = 3;
+        const idsPreview = affectedIds.slice(0, MAX_ID_DISPLAY).join(", ");
+        const moreText = affectedIds.length > MAX_ID_DISPLAY ? "..." : "";
+        const errorMessage =
+          `${count} comment${count > 1 ? "s" : ""} exceed${count === 1 ? "s" : ""} the ${maxLength.toLocaleString()} character limit. ` +
+          `Please segment your data. Affected: ${idsPreview}${moreText}`;
+        setInlineError(errorMessage);
+        handleReset(inputRef);
       } else if (result.error.tag === "Invalid CSV") {
         // Invalid CSV - show error modal and reset file
         setErrorModalState({

--- a/pipeline-worker/src/pipeline-steps/clustering/__tests__/clustering.test.ts
+++ b/pipeline-worker/src/pipeline-steps/clustering/__tests__/clustering.test.ts
@@ -121,11 +121,13 @@ describe("Clustering Pipeline Step", () => {
         }
       });
 
-      it("should truncate oversized comments", () => {
+      it("should reject oversized comments (defense-in-depth)", () => {
         const longText = "a".repeat(15000);
         const { sanitizedText, isSafe } = basicSanitize(longText, "test");
-        expect(isSafe).toBe(true);
-        expect(sanitizedText.length).toBeLessThanOrEqual(10000);
+        // Client-side validation should catch oversized comments
+        // If they reach the sanitizer, reject them as a safety net
+        expect(isSafe).toBe(false);
+        expect(sanitizedText).toBe("");
       });
     });
 

--- a/pipeline-worker/src/pipeline-steps/sanitizer.ts
+++ b/pipeline-worker/src/pipeline-steps/sanitizer.ts
@@ -93,13 +93,13 @@ export function basicSanitize(
 
   let sanitizedText = text;
 
-  // Basic length check
+  // Basic length check - reject oversized content (defense-in-depth)
   if (text.length > MAX_COMMENT_LENGTH) {
-    sanitizerLogger.warn(
+    sanitizerLogger.error(
       { context, length: text.length, maxLength: MAX_COMMENT_LENGTH },
-      "Oversized input detected",
+      "Oversized input rejected - client-side validation bypassed",
     );
-    sanitizedText = text.substring(0, MAX_COMMENT_LENGTH);
+    return { sanitizedText: "", isSafe: false };
   }
 
   // Empty or too short

--- a/pyserver/simple_sanitizer.py
+++ b/pyserver/simple_sanitizer.py
@@ -69,10 +69,10 @@ def basic_sanitize(text: str, context: str = "", filter_pii_flag: bool = True) -
     if not isinstance(text, str):
         return "", False
     
-    # Basic length check
+    # Basic length check - reject oversized content (defense-in-depth)
     if len(text) > MAX_COMMENT_LENGTH:
-        logger.warning(f"Oversized input in {context}: {len(text)} chars")
-        text = text[:MAX_COMMENT_LENGTH]
+        logger.error(f"Oversized input rejected in {context}: {len(text)} chars - client validation bypassed")
+        return "", False
     
     # Empty or too short
     if len(text.strip()) < 3:


### PR DESCRIPTION
## Summary

- **Hard error at 10,000 characters**: Blocks CSV submission with actionable error showing affected IDs
- **Soft warning at 5,000 characters**: Suggests segmentation for better quality but allows proceeding
- **Defense-in-depth**: Sanitizers now reject (not truncate) oversized content if client validation is bypassed

Resolves the issue where comments exceeding 10K characters were silently truncated in the pipeline without user notification.