### PR TITLE
T3C-1035: Fix ephemeral cleanup incorrectly deleting open PR environments

### DIFF
--- a/.github/workflows/ephemeral-cleanup.yml
+++ b/.github/workflows/ephemeral-cleanup.yml
@@ -41,7 +41,9 @@ jobs:
           echo "Finding orphaned ephemeral environments..."
 
           # Get list of open PR numbers (with error handling)
-          if ! OPEN_PRS=$(gh pr list --state=open --json number --jq '.[].number' | sort -n); then
+          # Note: --limit 500 is required because gh pr list defaults to 30 results,
+          # which can cause older but still-open PRs to be incorrectly identified as orphaned
+          if ! OPEN_PRS=$(gh pr list --state=open --limit 500 --json number --jq '.[].number' | sort -n); then
             echo "ERROR: Failed to fetch open PRs from GitHub. Aborting to prevent accidental deletion."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Add `--limit 500` to `gh pr list` command in ephemeral cleanup workflow
- The default limit of 30 results caused older but still-open PRs to be incorrectly identified as orphaned

## Root Cause
When there are more than 30 open PRs, the default `gh pr list` only returns the 30 most recently updated. Older PRs (like #493) get deleted even though they're still open.