### PR TITLE
T3C-1037: Tag Docker images with git SHA and add gcloud --quiet

### DIFF
--- a/.github/workflows/deploy-express-server-production.yml
+++ b/.github/workflows/deploy-express-server-production.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -41,18 +44,19 @@ jobs:
           docker build \
             --build-arg TURBO_TOKEN=${{ secrets.TURBO_TOKEN }} \
             --build-arg TURBO_TEAM=${{ secrets.TURBO_TEAM }} \
-            -t gcr.io/tttc-light-js/t3c-express-server \
+            -t gcr.io/tttc-light-js/t3c-express-server:${{ env.SHORT_SHA }} \
             -f express-server/Dockerfile .
 
       - name: Push Docker image
         run: |
-          gcloud auth configure-docker
-          docker push gcr.io/tttc-light-js/t3c-express-server
+          gcloud auth configure-docker --quiet
+          docker push gcr.io/tttc-light-js/t3c-express-server:${{ env.SHORT_SHA }}
 
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy ts-server-brandon \
-            --image gcr.io/tttc-light-js/t3c-express-server \
+            --image gcr.io/tttc-light-js/t3c-express-server:${{ env.SHORT_SHA }} \
             --platform managed \
             --region us-central1 \
-            --allow-unauthenticated
+            --allow-unauthenticated \
+            --quiet

--- a/.github/workflows/deploy-express-server.yml
+++ b/.github/workflows/deploy-express-server.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -43,18 +46,19 @@ jobs:
           docker build \
             --build-arg TURBO_TOKEN=${{ secrets.TURBO_TOKEN }} \
             --build-arg TURBO_TEAM=${{ secrets.TURBO_TEAM }} \
-            -t gcr.io/tttc-light-js/stage-t3c-express-server \
+            -t gcr.io/tttc-light-js/stage-t3c-express-server:${{ env.SHORT_SHA }} \
             -f express-server/Dockerfile .
 
       - name: Push Docker image
         run: |
-          gcloud auth configure-docker
-          docker push gcr.io/tttc-light-js/stage-t3c-express-server
+          gcloud auth configure-docker --quiet
+          docker push gcr.io/tttc-light-js/stage-t3c-express-server:${{ env.SHORT_SHA }}
 
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy stage-t3c-express-server \
-            --image gcr.io/tttc-light-js/stage-t3c-express-server \
+            --image gcr.io/tttc-light-js/stage-t3c-express-server:${{ env.SHORT_SHA }} \
             --platform managed \
             --region us-central1 \
-            --allow-unauthenticated
+            --allow-unauthenticated \
+            --quiet

--- a/.github/workflows/deploy-next-client-production.yml
+++ b/.github/workflows/deploy-next-client-production.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -44,21 +47,22 @@ jobs:
           docker build \
             --build-arg TURBO_TOKEN=${{ secrets.TURBO_TOKEN }} \
             --build-arg TURBO_TEAM=${{ secrets.TURBO_TEAM }} \
-            -t gcr.io/tttc-light-js/t3c-next-client \
+            -t gcr.io/tttc-light-js/t3c-next-client:${{ env.SHORT_SHA }} \
             -f next-client/Dockerfile .
 
       - name: Push Docker image
         run: |
-          gcloud auth configure-docker
-          docker push gcr.io/tttc-light-js/t3c-next-client
+          gcloud auth configure-docker --quiet
+          docker push gcr.io/tttc-light-js/t3c-next-client:${{ env.SHORT_SHA }}
 
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy t3c-next-client \
-            --image gcr.io/tttc-light-js/t3c-next-client \
+            --image gcr.io/tttc-light-js/t3c-next-client:${{ env.SHORT_SHA }} \
             --platform managed \
             --region us-central1 \
-            --allow-unauthenticated
+            --allow-unauthenticated \
+            --quiet
 
       - name: Remove .env file
         run: rm -f next-client/.env

--- a/.github/workflows/deploy-next-client.yml
+++ b/.github/workflows/deploy-next-client.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -47,21 +50,22 @@ jobs:
           docker build \
             --build-arg TURBO_TOKEN=${{ secrets.TURBO_TOKEN }} \
             --build-arg TURBO_TEAM=${{ secrets.TURBO_TEAM }} \
-            -t gcr.io/tttc-light-js/t3c-next-client-staging \
+            -t gcr.io/tttc-light-js/t3c-next-client-staging:${{ env.SHORT_SHA }} \
             -f next-client/Dockerfile .
 
       - name: Push Docker image
         run: |
-          gcloud auth configure-docker
-          docker push gcr.io/tttc-light-js/t3c-next-client-staging
+          gcloud auth configure-docker --quiet
+          docker push gcr.io/tttc-light-js/t3c-next-client-staging:${{ env.SHORT_SHA }}
 
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy t3c-next-client-staging \
-            --image gcr.io/tttc-light-js/t3c-next-client-staging \
+            --image gcr.io/tttc-light-js/t3c-next-client-staging:${{ env.SHORT_SHA }} \
             --platform managed \
             --region us-central1 \
-            --allow-unauthenticated
+            --allow-unauthenticated \
+            --quiet
 
       - name: Remove .env file
         run: rm -f next-client/.env

--- a/.github/workflows/deploy-pyserver-production.yml
+++ b/.github/workflows/deploy-pyserver-production.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -37,18 +40,19 @@ jobs:
       ####
       - name: Build Docker image
         run: |
-          docker build -t gcr.io/tttc-light-js/pyserver-brandon -f pyserver/Dockerfile .
+          docker build -t gcr.io/tttc-light-js/pyserver-brandon:${{ env.SHORT_SHA }} -f pyserver/Dockerfile .
 
       - name: Push Docker image
         run: |
-          gcloud auth configure-docker
-          docker push gcr.io/tttc-light-js/pyserver-brandon
+          gcloud auth configure-docker --quiet
+          docker push gcr.io/tttc-light-js/pyserver-brandon:${{ env.SHORT_SHA }}
 
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy pyserver-brandon \
-            --image gcr.io/tttc-light-js/pyserver-brandon \
+            --image gcr.io/tttc-light-js/pyserver-brandon:${{ env.SHORT_SHA }} \
             --platform managed \
             --region us-central1 \
             --allow-unauthenticated \
-            --vpc-connector projects/tttc-light-js/locations/us-central1/connectors/prod-us-central1-vpc-con
+            --vpc-connector projects/tttc-light-js/locations/us-central1/connectors/prod-us-central1-vpc-con \
+            --quiet

--- a/.github/workflows/deploy-pyserver.yml
+++ b/.github/workflows/deploy-pyserver.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -39,18 +42,19 @@ jobs:
       ####
       - name: Build Docker image
         run: |
-          docker build -t gcr.io/tttc-light-js/stage-t3c-pyserver -f pyserver/Dockerfile .
+          docker build -t gcr.io/tttc-light-js/stage-t3c-pyserver:${{ env.SHORT_SHA }} -f pyserver/Dockerfile .
 
       - name: Push Docker image
         run: |
-          gcloud auth configure-docker
-          docker push gcr.io/tttc-light-js/stage-t3c-pyserver
+          gcloud auth configure-docker --quiet
+          docker push gcr.io/tttc-light-js/stage-t3c-pyserver:${{ env.SHORT_SHA }}
 
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy stage-t3c-pyserver \
-            --image gcr.io/tttc-light-js/stage-t3c-pyserver \
+            --image gcr.io/tttc-light-js/stage-t3c-pyserver:${{ env.SHORT_SHA }} \
             --platform managed \
             --region us-central1 \
             --allow-unauthenticated \
-            --vpc-connector projects/tttc-light-js/locations/us-central1/connectors/prod-us-central1-vpc-con
+            --vpc-connector projects/tttc-light-js/locations/us-central1/connectors/prod-us-central1-vpc-con \
+            --quiet


### PR DESCRIPTION
## Summary

- Add git SHA tags to Docker images for all staging/production deployments
- Add `--quiet` flag to gcloud commands to reduce CI noise

## Changes

For all 6 deployment workflows:
- Add `Set short SHA` step extracting `${GITHUB_SHA:0:7}` 
- Tag images with `:${{ env.SHORT_SHA }}` (e.g., `:a1b2c3d`)
- Add `--quiet` to `gcloud auth configure-docker`
- Add `--quiet` to `gcloud run deploy`

## Why

- **Traceability**: Can now trace any deployed image back to its exact commit
- **Debugging**: Easier to identify which commit is running in staging/production
- **Rollbacks**: Cloud Run revision list now shows meaningful tags
- **Cleaner logs**: `--quiet` suppresses interactive prompts

Closes T3C-1037