### PR TITLE
T3C-1040: Add TypeScript checking to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,3 +8,28 @@ pnpm exec biome check --write --staged --no-errors-on-unmatched --files-ignore-u
 git update-index --again
 
 echo "Biome check complete!"
+
+# TypeScript check for changed packages
+echo "Running TypeScript check on changed packages..."
+
+CHANGED=""
+git diff --cached --name-only | grep -q "^express-server/" && CHANGED="$CHANGED express-server"
+git diff --cached --name-only | grep -q "^next-client/" && CHANGED="$CHANGED next-client"
+git diff --cached --name-only | grep -q "^common/" && CHANGED="$CHANGED tttc-common"
+git diff --cached --name-only | grep -q "^pipeline-worker/" && CHANGED="$CHANGED pipeline-worker"
+
+if [ -n "$CHANGED" ]; then
+  # Build common first if changed (other packages depend on it)
+  if echo "$CHANGED" | grep -q "tttc-common"; then
+    echo "Building tttc-common..."
+    pnpm --filter=tttc-common run build || exit 1
+  fi
+
+  # Typecheck each changed package
+  for pkg in $CHANGED; do
+    echo "Typechecking $pkg..."
+    pnpm --filter=$pkg exec tsc --noEmit || exit 1
+  done
+fi
+
+echo "TypeScript check complete!"


### PR DESCRIPTION
## Summary

- Adds TypeScript type checking to pre-commit hook
- Detects which packages have staged changes and only typechecks those
- Builds `tttc-common` first if it has changes (other packages depend on it)
- Blocking on failure - prevents commits with type errors

## Motivation

Analysis of recent CI failures showed ~20% were TypeScript errors that could have been caught locally. This reduces CI costs and provides faster feedback.

## Notes

Developers can bypass with `git commit --no-verify` for emergencies.

Closes T3C-1040