### PR TITLE
T3C-1048: Fix Navbar hydration mismatch

### DIFF
--- a/next-client/src/components/navbar/Navbar.tsx
+++ b/next-client/src/components/navbar/Navbar.tsx
@@ -16,9 +16,11 @@ import {
 const LoginButton = dynamic(() => import("./components/LoginButton"), {
   ssr: false,
   loading: () => (
-    <Button disabled className="min-w-[80px]">
-      ...
-    </Button>
+    <div>
+      <Button disabled className="min-w-[80px]">
+        ...
+      </Button>
+    </div>
   ),
 });
 


### PR DESCRIPTION
## Summary

- Add wrapper `<div>` to LoginButton loading fallback to match the actual component structure
- The LoginButton component always wraps its content in a `<div>`, but the loading fallback was rendering just a `<Button>`, causing a tree structure mismatch during hydration