### PR TITLE
T3C-1049: Show spinner instead of progress bar in report loading skeleton

### DIFF
--- a/next-client/src/app/report/[uri]/loading.tsx
+++ b/next-client/src/app/report/[uri]/loading.tsx
@@ -1,11 +1,10 @@
-import { Progress } from "@/components/elements";
+import { Spinner } from "@/components/elements";
 import { Col } from "@/components/layout";
 
 export default function ReportLoading() {
   return (
     <Col className="w-full h-full flex-grow items-center justify-center">
-      <Progress value={0} className="w-[60%]" />
-      <p>Your report is queued...</p>
+      <Spinner className="size-8" label="Loading report" />
     </Col>
   );
 }


### PR DESCRIPTION
## Summary

- Replace progress bar + "Your report is queued..." text with a simple spinner in the Next.js loading skeleton
- The loading.tsx skeleton shows during navigation for ALL reports, so it shouldn't imply a specific state
- The ReportProgress component still shows detailed progress for reports actually being processed