### PR TITLE
T3C-1058: Fix agreement score clamping for crux analysis

### DIFF
--- a/common/schema/__tests__/crux-deduplication.test.ts
+++ b/common/schema/__tests__/crux-deduplication.test.ts
@@ -351,3 +351,62 @@ describe("SubtopicCrux Speaker Deduplication", () => {
     });
   });
 });
+
+describe("SubtopicCrux Score Clamping", () => {
+  const baseValidCrux = {
+    topic: "AI Safety",
+    subtopic: "Regulation",
+    cruxClaim: "Government should regulate AI development",
+    agree: ["1:Alice"],
+    disagree: ["2:Bob"],
+    no_clear_position: [],
+    explanation: "Test explanation",
+    speakersInvolved: 2,
+    totalSpeakersInSubtopic: 5,
+  };
+
+  it("clamps scores above 1.0 to 1.0", () => {
+    const input = {
+      ...baseValidCrux,
+      agreementScore: 1.5,
+      disagreementScore: 2.0,
+      controversyScore: 1.2,
+    };
+
+    const result = subtopicCrux.parse(input);
+
+    expect(result.agreementScore).toBe(1.0);
+    expect(result.disagreementScore).toBe(1.0);
+    expect(result.controversyScore).toBe(1.0);
+  });
+
+  it("clamps scores below 0.0 to 0.0", () => {
+    const input = {
+      ...baseValidCrux,
+      agreementScore: -0.1,
+      disagreementScore: -0.5,
+      controversyScore: -1.0,
+    };
+
+    const result = subtopicCrux.parse(input);
+
+    expect(result.agreementScore).toBe(0.0);
+    expect(result.disagreementScore).toBe(0.0);
+    expect(result.controversyScore).toBe(0.0);
+  });
+
+  it("preserves valid scores within [0, 1] range", () => {
+    const input = {
+      ...baseValidCrux,
+      agreementScore: 0.0,
+      disagreementScore: 0.5,
+      controversyScore: 1.0,
+    };
+
+    const result = subtopicCrux.parse(input);
+
+    expect(result.agreementScore).toBe(0.0);
+    expect(result.disagreementScore).toBe(0.5);
+    expect(result.controversyScore).toBe(1.0);
+  });
+});

--- a/common/schema/index.ts
+++ b/common/schema/index.ts
@@ -570,16 +570,13 @@ export const subtopicCrux = z
     explanation: z.string(), // LLM's reasoning for why this divides participants
     agreementScore: z
       .number()
-      .min(0, "Agreement score must be between 0 and 1")
-      .max(1, "Agreement score must be between 0 and 1"), // 0-1: ratio of speakers who agree
+      .transform((val) => Math.max(0, Math.min(1, val))), // Clamp to 0-1 range
     disagreementScore: z
       .number()
-      .min(0, "Disagreement score must be between 0 and 1")
-      .max(1, "Disagreement score must be between 0 and 1"), // 0-1: ratio of speakers who disagree
+      .transform((val) => Math.max(0, Math.min(1, val))), // Clamp to 0-1 range
     controversyScore: z
       .number()
-      .min(0, "Controversy score must be between 0 and 1")
-      .max(1, "Controversy score must be between 0 and 1"), // 0-1: how evenly split (1.0 = perfect 50/50 split)
+      .transform((val) => Math.max(0, Math.min(1, val))), // Clamp to 0-1 range
     speakersInvolved: z.number().int().nonnegative().optional(), // Total speakers who took a position (agree + disagree)
     totalSpeakersInSubtopic: z.number().int().nonnegative().optional(), // Total speakers with claims in this subtopic
   })

--- a/pyserver/main.py
+++ b/pyserver/main.py
@@ -2099,6 +2099,23 @@ def calculate_controversy_scores(agree_speakers: list, disagree_speakers: list, 
     # min() gives us the smaller group, *2 normalizes to 0-1 range
     controversy_score = min(agreement_score, disagreement_score) * 2
 
+    # Clamp all scores to [0, 1] range to handle edge cases where
+    # agree/disagree counts exceed total_speakers due to data inconsistencies
+    needs_clamping = (
+        agreement_score < 0.0 or agreement_score > 1.0 or
+        disagreement_score < 0.0 or disagreement_score > 1.0 or
+        controversy_score < 0.0 or controversy_score > 1.0
+    )
+    if needs_clamping:
+        logger.warning(
+            f"Clamping out-of-range scores: agreement={agreement_score:.3f}, "
+            f"disagreement={disagreement_score:.3f}, controversy={controversy_score:.3f} "
+            f"(agree={num_agree}, disagree={num_disagree}, total={total_speakers})"
+        )
+    agreement_score = max(0.0, min(1.0, agreement_score))
+    disagreement_score = max(0.0, min(1.0, disagreement_score))
+    controversy_score = max(0.0, min(1.0, controversy_score))
+
     return {
         "agreementScore": agreement_score,
         "disagreementScore": disagreement_score,


### PR DESCRIPTION
## Summary
- Clamp `agreementScore`, `disagreementScore`, and `controversyScore` to [0, 1] range to handle edge cases where speaker counts exceed total speakers due to data inconsistencies
- Add warning logging when clamping occurs to help identify upstream issues
- Add test coverage for score clamping behavior

## Changes
- **pyserver/main.py**: Add clamping with warning log in `calculate_controversy_scores()`
- **common/schema/index.ts**: Change Zod validation from `.min()/.max()` to `.transform()` with clamping
- **common/schema/__tests__/crux-deduplication.test.ts**: Add tests for clamping behavior