### PR TITLE
T3C-1083 Fix Next.js image import and add spell check words

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -202,6 +202,7 @@
     "refstore",
     "refstores",
     "REFSTORE",
+    "bucketstore",
     "googlepubsub",
     "pubsubs",
     "nextclient",

--- a/next-client/src/assets/hero/LandingHero.tsx
+++ b/next-client/src/assets/hero/LandingHero.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import { cn } from "@/lib/utils/shadcn";
-import heroImage from "../../../public/images/t3c-product-desktop-mobile.png";
 
 export default function LandingHero({ className }: { className?: string }) {
   return (
@@ -9,13 +8,14 @@ export default function LandingHero({ className }: { className?: string }) {
       style={{ aspectRatio: "1764/1218" }}
     >
       <Image
-        src={heroImage}
+        src="/images/t3c-product-desktop-mobile.png"
         alt="Talk to the City product interface dashboard"
         priority
         quality={85}
+        width={1764}
+        height={1218}
         className="w-full h-auto"
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 90vw, 1764px"
-        placeholder="blur"
       />
     </div>
   );


### PR DESCRIPTION
- Fix LandingHero.tsx to use proper Next.js image path instead of importing from public directory
- Add 'bucketstore' to spell check dictionary