### PR TITLE
T3C-1084 Move pipelineJobSchema to common package for reuse

### DIFF
--- a/common/schema/index.ts
+++ b/common/schema/index.ts
@@ -1231,3 +1231,6 @@ const downloadReportSchema_v1 = z.tuple([
 export const downloadReportSchema = downloadReportSchema_v1;
 
 export type DownloadDataReportSchema = z.infer<typeof downloadReportSchema>;
+
+// Pipeline job message schema for queue communication
+export { type PipelineJobMessage, pipelineJobSchema } from "./pipelineJob.js";

--- a/common/schema/pipelineJob.ts
+++ b/common/schema/pipelineJob.ts
@@ -1,0 +1,64 @@
+/**
+ * Schema for pipeline job messages
+ * Shared between express-server (producer) and pipeline-worker (consumer)
+ */
+
+import { z } from "zod";
+
+/**
+ * Schema for comment in pipeline job
+ */
+const commentSchema = z.object({
+  comment_id: z.string(),
+  comment_text: z.string(),
+  speaker: z.string().default("participant"),
+  votes: z.number().optional(),
+  agrees: z.number().optional(),
+  disagrees: z.number().optional(),
+});
+
+/**
+ * Schema for Firebase details in pipeline job
+ */
+const firebaseDetailsSchema = z.object({
+  reportId: z.string(),
+  userId: z.string(),
+});
+
+/**
+ * Schema for pipeline job message
+ */
+export const pipelineJobSchema = z.object({
+  config: z.object({
+    firebaseDetails: firebaseDetailsSchema,
+    llm: z.object({
+      model: z.string(),
+    }),
+    instructions: z.object({
+      systemInstructions: z.string(),
+      clusteringInstructions: z.string(),
+      extractionInstructions: z.string(),
+      dedupInstructions: z.string(),
+      summariesInstructions: z.string(),
+      cruxInstructions: z.string(),
+      outputLanguage: z.string().optional(),
+    }),
+    options: z.object({
+      cruxes: z.boolean(),
+      bridging: z.boolean().optional(),
+      sortStrategy: z.enum(["numPeople", "numClaims"]).default("numPeople"),
+    }),
+    env: z.object({
+      OPENAI_API_KEY: z.string(),
+    }),
+  }),
+  data: z.array(commentSchema),
+  reportDetails: z.object({
+    title: z.string(),
+    description: z.string(),
+    question: z.string(),
+    filename: z.string(),
+  }),
+});
+
+export type PipelineJobMessage = z.infer<typeof pipelineJobSchema>;

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -16,7 +16,7 @@
     "lib": ["ES2024", "DOM"]
   },
   "include": [
-    "*",
+    "src/*",
     "./analytics/**/*",
     "./api/*",
     "./apiPyserver/*",
@@ -31,7 +31,7 @@
     "./transforms/**/*",
     "./permissions/*",
     "./prompts/*",
-    "./schema/*",
+    "./schema/**/*",
     "./types/*",
     "./utils/*",
     "./test-utils/**/*"


### PR DESCRIPTION
- Create common/schema/pipelineJob.ts with schema definition
- Export from common/schema/index.ts
- Fix common/tsconfig.json to include schema/**/* files

This enables both express-server and pipeline-worker to use the same schema for pipeline job validation.