### PR TITLE
T3C-1070: Add elicitation event zod schemas

### DIFF
--- a/common/api/index.ts
+++ b/common/api/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { elicitationEventSummary } from "../firebase";
 import * as schema from "../schema";
 
 export const generateApiRequest = z.object({
@@ -74,3 +75,12 @@ export type CreateReportActionResult =
   | { status: "idle" }
   | { status: "success"; data: GenerateApiResponse }
   | { status: "error"; error: FormActionError };
+
+// GET /api/elicitation/events response
+export const elicitationEventsResponse = z.object({
+  events: z.array(elicitationEventSummary),
+});
+
+export type ElicitationEventsResponse = z.infer<
+  typeof elicitationEventsResponse
+>;

--- a/common/firebase/index.ts
+++ b/common/firebase/index.ts
@@ -176,6 +176,23 @@ export const userDocument = z.object({
 
 export type UserDocument = z.infer<typeof userDocument>;
 
+// Elicitation event summary for tracking page
+export const elicitationEventSummary = z.object({
+  id: z.string(), // Event document ID
+  eventName: z.string(), // Human-readable event name
+  ownerUserId: z.string(), // Firebase UID of owner
+  responderCount: z.number(), // Count of participants
+  createdAt: z.preprocess(
+    (arg) =>
+      firebaseTimestamp.safeParse(arg).success
+        ? new Date((arg as FirebaseTimestamp).seconds * 1000)
+        : arg,
+    z.date(),
+  ),
+});
+
+export type ElicitationEventSummary = z.infer<typeof elicitationEventSummary>;
+
 const COLLECTIONS = {
   REPORT_REF: "reportRef",
   REPORT_JOB: "reportJob",


### PR DESCRIPTION
## Summary

- Add `ElicitationEventSummary` schema to `common/firebase/index.ts` for tracking elicitation events with participant counts and metadata
- Add `ElicitationEventsResponse` schema to `common/api/index.ts` for the `GET /api/elicitation/events` endpoint
- Follows existing schema patterns with Firebase timestamp preprocessing

## Test plan

- [x] Common package builds successfully
- [x] All tests pass (508 tests)
- [x] Code formatted with Biome
- [x] TypeScript compilation passes
- [ ] Verify schemas work with actual Firestore data structure
- [ ] Test API endpoint integration (when implemented)