### PR TITLE
T3C-1071: Add event organizer role and permissions

### DIFF
--- a/common/api/index.ts
+++ b/common/api/index.ts
@@ -55,6 +55,7 @@ export type MigrationApiResponse = z.infer<typeof migrationApiResponse>;
 
 export const userCapabilitiesResponse = z.object({
   csvSizeLimit: z.number().min(0),
+  canViewElicitationTracking: z.boolean(),
   // Future capabilities can be added here
 });
 

--- a/common/permissions/index.ts
+++ b/common/permissions/index.ts
@@ -17,6 +17,9 @@ export const CAPABILITIES = {
   large_uploads: {
     csvSizeLimit: LARGE_UPLOAD_CSV_SIZE_LIMIT,
   },
+  event_organizer: {
+    canViewElicitationTracking: true,
+  },
   // Future roles can be added here as needed
 } as const;
 
@@ -26,6 +29,15 @@ export const CAPABILITIES = {
 export const DEFAULT_LIMITS = {
   csvSizeLimit: DEFAULT_CSV_SIZE_LIMIT,
 } as const;
+
+/**
+ * Check if user has event organizer role
+ * @param roles Array of role strings from the user document
+ * @returns True if user has event_organizer role
+ */
+export function isEventOrganizer(roles: string[]): boolean {
+  return roles.includes("event_organizer");
+}
 
 /**
  * Get the CSV size limit for a user based on their roles
@@ -50,6 +62,7 @@ export function getUserCsvSizeLimit(roles: string[]): number {
 export function getUserCapabilities(roles: string[]) {
   return {
     csvSizeLimit: getUserCsvSizeLimit(roles),
+    canViewElicitationTracking: isEventOrganizer(roles),
     // Future capabilities can be added here
   };
 }


### PR DESCRIPTION
## Summary

Implements the event organizer role with elicitation tracking capability in the permissions system. Event organizers can now view elicitation tracking data through the `canViewElicitationTracking` permission.

## Changes

- Add `event_organizer` to CAPABILITIES with `canViewElicitationTracking: true`
- Add `isEventOrganizer(roles: string[])` helper function
- Update `getUserCapabilities()` to return `canViewElicitationTracking` based on role
- Extend `userCapabilitiesResponse` API schema to include the new field
- Add comprehensive unit tests for permission functions (14 tests)
- Update API schema validation tests (11 tests)
- Update server user endpoint tests (7 tests)

## Test Plan

- [x] All common package tests pass (516 tests)
- [x] All server user endpoint tests pass (14 tests)
- [x] Permission system correctly grants elicitation tracking capability
- [x] API schema validates the new field
- [x] Multiple roles combine correctly (e.g., large_uploads + event_organizer)

## Technical Details

The `/api/user/limits` endpoint now returns:
```json
{
  "csvSizeLimit": 153600,
  "canViewElicitationTracking": true
}
```

Users with the `event_organizer` role in their Firestore user document will receive `canViewElicitationTracking: true`, enabling access to elicitation tracking features.