### PR TITLE
T3C-1077: Update question schemas and add follow-up questions display

### DIFF
--- a/common/firebase/index.ts
+++ b/common/firebase/index.ts
@@ -230,8 +230,21 @@ export const elicitationEventSummary = z.object({
   whatsappLink: z.string().optional(),
   // Event questions (optional - may not exist on all events)
   mainQuestion: z.string().optional(), // Primary survey question
-  questions: z.array(z.string()).optional(), // Array of question strings
-  followUpQuestions: z.array(z.string()).optional(), // Array of follow-up question strings
+  questions: z
+    .array(
+      z.object({
+        id: z.number(),
+        text: z.string(),
+        asked_count: z.number(),
+      }),
+    )
+    .optional(), // Array of question objects
+  followUpQuestions: z
+    .object({
+      enabled: z.boolean(),
+      questions: z.array(z.string()),
+    })
+    .optional(), // Follow-up questions config with enabled flag and questions array
   initialMessage: z.string().optional(), // Opening/welcome message
   completionMessage: z.string().optional(), // Closing message
   // Link to generated report (if available) - DEPRECATED: use reportIds array instead

--- a/next-client/.storybook/main.ts
+++ b/next-client/.storybook/main.ts
@@ -20,19 +20,22 @@ const config: StorybookConfig = {
   },
   staticDirs: ["../public"],
   // Pass through environment variables to webpack for Firebase config
+  // Use mock values for Storybook if real env vars aren't available
   env: (config) => ({
     ...config,
     NEXT_PUBLIC_FIREBASE_API_KEY:
-      process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? "",
+      process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? "mock-api-key",
     NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN:
-      process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? "",
+      process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? "mock.firebaseapp.com",
     NEXT_PUBLIC_FIREBASE_PROJECT_ID:
-      process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? "",
+      process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? "mock-project",
     NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET:
-      process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? "",
+      process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ??
+      "mock-project.appspot.com",
     NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID:
-      process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? "",
-    NEXT_PUBLIC_FIREBASE_APP_ID: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? "",
+      process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? "123456789",
+    NEXT_PUBLIC_FIREBASE_APP_ID:
+      process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? "1:123456789:web:abcdef",
   }),
 };
 export default config;

--- a/next-client/src/components/elicitation/ElicitationEventDetail.stories.tsx
+++ b/next-client/src/components/elicitation/ElicitationEventDetail.stories.tsx
@@ -87,11 +87,27 @@ const mockEvent = {
   whatsappLink: "lorem-ipsum-wa",
   initialMessage: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
   questions: [
-    "Lorem ipsum",
-    "Lorem ipsum",
-    "Lorem ipsum",
-    "Lorem ipsum",
-    "Lorem ipsum",
+    { id: 1, text: "What is your overall impression of AI?", asked_count: 156 },
+    {
+      id: 2,
+      text: "How often do you interact with AI in your daily life?",
+      asked_count: 156,
+    },
+    {
+      id: 3,
+      text: "What concerns do you have about AI technology?",
+      asked_count: 156,
+    },
+    {
+      id: 4,
+      text: "Do you think AI will have a positive impact on society?",
+      asked_count: 156,
+    },
+    {
+      id: 5,
+      text: "What AI applications are you most interested in?",
+      asked_count: 156,
+    },
   ],
   completionMessage: "Lorem ipsum dolor sit...",
   mode: "standard" as const,
@@ -105,11 +121,34 @@ export const Default: Story = {
   },
 };
 
-export const WithFollowUpMode: Story = {
+export const WithFollowUpQuestions: Story = {
   args: {
     event: {
       ...mockEvent,
       mode: "followup" as const,
+      followUpQuestions: {
+        enabled: true,
+        questions: [
+          "Can you elaborate on your previous answer?",
+          "What specific examples can you provide?",
+          "How has this affected your daily routine?",
+        ],
+      },
+    },
+  },
+};
+
+export const WithFollowUpQuestionsDisabled: Story = {
+  args: {
+    event: {
+      ...mockEvent,
+      followUpQuestions: {
+        enabled: false,
+        questions: [
+          "This question should not appear",
+          "Neither should this one",
+        ],
+      },
     },
   },
 };

--- a/next-client/src/components/elicitation/ElicitationEventDetail.tsx
+++ b/next-client/src/components/elicitation/ElicitationEventDetail.tsx
@@ -336,12 +336,14 @@ function WhatsAppLinkSection({ link }: { link: string }) {
 }
 
 /**
- * Content sections: opening message, survey questions, closing message
+ * Content sections: opening message, survey questions, follow-up questions, closing message
  */
 function EventContentSections({ event }: { event: ElicitationEventSummary }) {
   const hasContent =
     event.initialMessage ||
     (event.questions && event.questions.length > 0) ||
+    (event.followUpQuestions?.enabled &&
+      event.followUpQuestions.questions.length > 0) ||
     event.completionMessage;
 
   if (!hasContent) {
@@ -374,18 +376,38 @@ function EventContentSections({ event }: { event: ElicitationEventSummary }) {
           </CardHeader>
           <CardContent>
             <ol className="list-decimal list-inside space-y-2">
-              {event.questions.map((question, index) => (
-                <li
-                  key={`q-${index}-${question.slice(0, 30)}`}
-                  className="text-sm text-slate-600"
-                >
-                  {question}
+              {event.questions.map((question) => (
+                <li key={`q-${question.id}`} className="text-sm text-slate-600">
+                  {question.text}
                 </li>
               ))}
             </ol>
           </CardContent>
         </Card>
       )}
+
+      {event.followUpQuestions?.enabled &&
+        event.followUpQuestions.questions.length > 0 && (
+          <Card className="border-slate-200 shadow-sm">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-lg font-semibold">
+                Follow-up questions
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ol className="list-decimal list-inside space-y-2">
+                {event.followUpQuestions.questions.map((question, index) => (
+                  <li
+                    key={`fq-${index}-${question.slice(0, 30)}`}
+                    className="text-sm text-slate-600"
+                  >
+                    {question}
+                  </li>
+                ))}
+              </ol>
+            </CardContent>
+          </Card>
+        )}
 
       {event.completionMessage && (
         <Card className="border-slate-200 shadow-sm">

--- a/next-client/src/components/elicitation/ElicitationTrackingContent.tsx
+++ b/next-client/src/components/elicitation/ElicitationTrackingContent.tsx
@@ -186,12 +186,9 @@ export function EventCard({ event }: EventCardProps) {
                   Questions:{" "}
                 </span>
                 <ul className="list-disc list-inside mt-1 space-y-1">
-                  {questions.map((q, i) => (
-                    <li
-                      key={`q-${i}-${q.slice(0, 20)}`}
-                      className="line-clamp-1"
-                    >
-                      {q}
+                  {questions.map((q) => (
+                    <li key={`q-${q.id}`} className="line-clamp-1">
+                      {q.text}
                     </li>
                   ))}
                 </ul>
@@ -199,23 +196,24 @@ export function EventCard({ event }: EventCardProps) {
             )}
 
             {/* Follow-up Questions */}
-            {followUpQuestions && followUpQuestions.length > 0 && (
-              <div className="text-sm">
-                <span className="font-medium text-muted-foreground">
-                  Follow-up Questions:{" "}
-                </span>
-                <ul className="list-disc list-inside mt-1 space-y-1">
-                  {followUpQuestions.map((q, i) => (
-                    <li
-                      key={`fq-${i}-${q.slice(0, 20)}`}
-                      className="line-clamp-1"
-                    >
-                      {q}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
+            {followUpQuestions?.enabled &&
+              followUpQuestions.questions.length > 0 && (
+                <div className="text-sm">
+                  <span className="font-medium text-muted-foreground">
+                    Follow-up Questions:{" "}
+                  </span>
+                  <ul className="list-disc list-inside mt-1 space-y-1">
+                    {followUpQuestions.questions.map((q, i) => (
+                      <li
+                        key={`fq-${i}-${q.slice(0, 20)}`}
+                        className="line-clamp-1"
+                      >
+                        {q}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
 
             {/* Opening Message */}
             {initialMessage && (


### PR DESCRIPTION
- Update questions schema to use objects with id, text, and asked_count fields
- Update followUpQuestions schema to object with enabled flag and questions array
- Add follow-up questions section to elicitation event detail page
- Update ElicitationTrackingContent to handle new question schema
- Update Storybook stories with new question format and follow-up examples
- Add mock Firebase config values for Storybook