### PR TITLE
T3C-1116 Fix repeated claim bug by assigning unique IDs in format-output

### DIFF
--- a/pipeline-worker/src/pipeline-runner/format-output.ts
+++ b/pipeline-worker/src/pipeline-runner/format-output.ts
@@ -7,6 +7,7 @@
  * schema format.
  */
 
+import { randomUUID } from "node:crypto";
 import type * as schema from "tttc-common/schema";
 import type { PipelineJobMessage } from "tttc-common/schema";
 import type { DedupedClaim } from "../pipeline-steps/types";
@@ -112,13 +113,12 @@ export function formatPipelineOutput(
 
 /**
  * Convert DedupedClaim to LLMClaim format recursively
- * Note: DedupedClaim doesn't have claimId field - IDs are array indices
  */
 function convertDedupedClaimToLLMClaim(claim: DedupedClaim): schema.LLMClaim {
   const llmClaim: schema.LLMClaim = {
     claim: claim.claim,
     quote: claim.quote,
-    claimId: undefined, // No claim IDs in pipeline-worker format
+    claimId: randomUUID(),
     topicName: claim.topicName,
     subtopicName: claim.subtopicName,
     commentId: claim.commentId,


### PR DESCRIPTION
All claims had claimId: undefined, causing buildClaimsMap to store every claim under the key "undefined", with each overwriting the previous. Every subtopic then resolved to the same last claim.

Fix by generating a randomUUID() for each claim (and its duplicates) in convertDedupedClaimToLLMClaim.