### PR TITLE
T3C-1188 Pass PostHog distinct_id to server-side website-redesign flag check

### DIFF
--- a/next-client/src/app/about/page.tsx
+++ b/next-client/src/app/about/page.tsx
@@ -7,6 +7,7 @@ import {
   initializeFeatureFlags,
   isFeatureEnabled,
 } from "@/lib/feature-flags/featureFlags.server";
+import { getPostHogDistinctId } from "@/lib/feature-flags/getPostHogDistinctId";
 
 export const dynamic = "force-dynamic";
 
@@ -60,7 +61,10 @@ export default async function AboutPage() {
   initializeFeatureFlags();
   const analytics = await serverSideAnalyticsClient();
   await analytics.page("About");
-  const redesignEnabled = await isFeatureEnabled("website-redesign");
+  const distinctId = await getPostHogDistinctId();
+  const redesignEnabled = await isFeatureEnabled("website-redesign", {
+    userId: distinctId,
+  });
   if (redesignEnabled) {
     return <AboutRedesign />;
   }

--- a/next-client/src/app/page.tsx
+++ b/next-client/src/app/page.tsx
@@ -6,6 +6,7 @@ import {
   initializeFeatureFlags,
   isFeatureEnabled,
 } from "@/lib/feature-flags/featureFlags.server";
+import { getPostHogDistinctId } from "@/lib/feature-flags/getPostHogDistinctId";
 
 export const dynamic = "force-dynamic";
 
@@ -17,7 +18,10 @@ export default async function HomePage() {
   initializeFeatureFlags();
   const analytics = await serverSideAnalyticsClient();
   await analytics.page("Home");
-  const redesignEnabled = await isFeatureEnabled("website-redesign");
+  const distinctId = await getPostHogDistinctId();
+  const redesignEnabled = await isFeatureEnabled("website-redesign", {
+    userId: distinctId,
+  });
   return (
     <div>
       {redesignEnabled ? <LandingRedesign /> : <Landing />}

--- a/next-client/src/app/safety/page.tsx
+++ b/next-client/src/app/safety/page.tsx
@@ -7,6 +7,7 @@ import {
   initializeFeatureFlags,
   isFeatureEnabled,
 } from "@/lib/feature-flags/featureFlags.server";
+import { getPostHogDistinctId } from "@/lib/feature-flags/getPostHogDistinctId";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +38,10 @@ export default async function SafetyPage() {
     console.error("Failed to track page view:", error);
   }
 
-  const redesignEnabled = await isFeatureEnabled("website-redesign");
+  const distinctId = await getPostHogDistinctId();
+  const redesignEnabled = await isFeatureEnabled("website-redesign", {
+    userId: distinctId,
+  });
   if (redesignEnabled) {
     return <SafetyRedesign />;
   }

--- a/next-client/src/lib/feature-flags/__tests__/getPostHogDistinctId.test.ts
+++ b/next-client/src/lib/feature-flags/__tests__/getPostHogDistinctId.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPostHogDistinctId } from "../getPostHogDistinctId";
+
+vi.mock("tttc-common/logger", () => ({
+  logger: {
+    child: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  },
+}));
+
+const { mockCookies } = vi.hoisted(() => ({
+  mockCookies: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}));
+
+function setCookies(entries: Array<{ name: string; value: string }>) {
+  mockCookies.mockResolvedValue({
+    getAll: () => entries,
+  });
+}
+
+describe("getPostHogDistinctId", () => {
+  beforeEach(() => {
+    mockCookies.mockReset();
+  });
+
+  it("returns the distinct_id from a URL-encoded PostHog cookie", async () => {
+    const state = { distinct_id: "user-abc123", $device_id: "device-xyz" };
+    setCookies([
+      {
+        name: "ph_phc_PROJECT_KEY_posthog",
+        value: encodeURIComponent(JSON.stringify(state)),
+      },
+    ]);
+
+    expect(await getPostHogDistinctId()).toBe("user-abc123");
+  });
+
+  it("parses a raw JSON cookie value (not URI-encoded)", async () => {
+    setCookies([
+      {
+        name: "ph_phc_PROJECT_KEY_posthog",
+        value: JSON.stringify({ distinct_id: "plain-id" }),
+      },
+    ]);
+
+    expect(await getPostHogDistinctId()).toBe("plain-id");
+  });
+
+  it("returns undefined when no PostHog cookie is present", async () => {
+    setCookies([{ name: "session", value: "abc" }]);
+    expect(await getPostHogDistinctId()).toBeUndefined();
+  });
+
+  it("returns undefined when the cookie is malformed JSON", async () => {
+    setCookies([
+      { name: "ph_key_posthog", value: encodeURIComponent("not-json{{{") },
+    ]);
+    expect(await getPostHogDistinctId()).toBeUndefined();
+  });
+
+  it("returns undefined when distinct_id field is missing", async () => {
+    setCookies([
+      {
+        name: "ph_key_posthog",
+        value: encodeURIComponent(JSON.stringify({ $device_id: "d" })),
+      },
+    ]);
+    expect(await getPostHogDistinctId()).toBeUndefined();
+  });
+
+  it("returns undefined when distinct_id is empty", async () => {
+    setCookies([
+      {
+        name: "ph_key_posthog",
+        value: encodeURIComponent(JSON.stringify({ distinct_id: "" })),
+      },
+    ]);
+    expect(await getPostHogDistinctId()).toBeUndefined();
+  });
+
+  it("ignores other cookies and only matches ph_*_posthog", async () => {
+    setCookies([
+      { name: "ph_session", value: "x" },
+      { name: "posthog", value: "y" },
+      {
+        name: "ph_real_posthog",
+        value: encodeURIComponent(JSON.stringify({ distinct_id: "real" })),
+      },
+    ]);
+
+    expect(await getPostHogDistinctId()).toBe("real");
+  });
+});

--- a/next-client/src/lib/feature-flags/getPostHogDistinctId.ts
+++ b/next-client/src/lib/feature-flags/getPostHogDistinctId.ts
@@ -1,0 +1,31 @@
+import { cookies } from "next/headers";
+import { logger } from "tttc-common/logger";
+
+const cookieLogger = logger.child({ module: "feature-flags-cookie" });
+
+// PostHog stores per-user state in a JSON cookie named `ph_<api-key>_posthog`.
+// Server components need to read this to evaluate per-user feature flags via the
+// Node SDK — otherwise every request is treated as the same anonymous visitor
+// and per-user targeting rules can never match.
+export async function getPostHogDistinctId(): Promise<string | undefined> {
+  const cookieStore = await cookies();
+  const phCookie = cookieStore
+    .getAll()
+    .find((c) => c.name.startsWith("ph_") && c.name.endsWith("_posthog"));
+
+  if (!phCookie) return undefined;
+
+  // posthog-js stores the cookie value as encodeURIComponent(JSON.stringify(state)).
+  try {
+    const parsed = JSON.parse(decodeURIComponent(phCookie.value));
+    if (
+      typeof parsed?.distinct_id === "string" &&
+      parsed.distinct_id.length > 0
+    ) {
+      return parsed.distinct_id;
+    }
+  } catch (error) {
+    cookieLogger.warn({ error }, "Failed to parse PostHog cookie");
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- Server-side `isFeatureEnabled("website-redesign")` calls in `page.tsx`, `about/page.tsx`, and `safety/page.tsx` were not passing any user context, so the PostHog Node SDK evaluated every request as the same anonymous user. Per-user release conditions could never match.
- New helper `getPostHogDistinctId` reads PostHog's `ph_*_posthog` cookie via `next/headers` and returns the visitor's distinct_id (URL-decoded JSON).
- All three pages now pass `{ userId: distinctId }` into the flag check, so PostHog targeting rules like `distinct_id equals <id>` work correctly. Falls back to `undefined` (anonymous) for first-time visitors with no cookie yet — a "100% of all users" rollout still matches.

## Linear

[T3C-1188](https://linear.app/aoi/issue/T3C-1188)

## Why this was broken

The other per-user flags in the app (`model_selection_enabled` in `CreateReport.tsx`, etc.) all run **client-side** and use `posthog-js`, which auto-reads the cookie. These three pages are **server components** using the Node SDK, which has no access to browser cookies unless we wire them through. That difference was missed when the redesign gating was first added.

## Test plan

- [ ] CI runs new unit tests in `__tests__/getPostHogDistinctId.test.ts` (7 cases: URL-encoded cookie, raw JSON, missing cookie, malformed JSON, missing field, empty distinct_id, look-alike cookies)
- [ ] PR preview deploy uses `LOCAL_FLAGS={"website-redesign": true}` — confirm the redesigned Home, About, and Safety pages render on the preview URL
- [ ] After merge, confirm on production that the existing `distinct_id equals fYZrC5...` PostHog rule starts matching the targeted user

🤖 Generated with [Claude Code](https://claude.com/claude-code)