### PR TITLE
T3C-1155 T3C-1156 New menu bars (front-facing and user-facing)

### DIFF
--- a/next-client/src/app/layout.tsx
+++ b/next-client/src/app/layout.tsx
@@ -1,5 +1,11 @@
 import { Toaster } from "@/components/elements";
 import Navbar from "@/components/navbar/Navbar";
+import NavbarRedesign from "@/components/navbar/NavbarRedesign";
+import {
+  initializeFeatureFlags,
+  isFeatureEnabled,
+} from "@/lib/feature-flags/featureFlags.server";
+import { getPostHogDistinctId } from "@/lib/feature-flags/getPostHogDistinctId";
 import { nextTypography } from "@/lib/font";
 import "./global.css";
 import type { Metadata } from "next";
@@ -49,6 +55,12 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  initializeFeatureFlags();
+  const distinctId = await getPostHogDistinctId();
+  const redesignEnabled = await isFeatureEnabled("website-redesign", {
+    userId: distinctId,
+  });
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -57,7 +69,7 @@ export default async function RootLayout({
       <body className={nextTypography}>
         <Providers>
           <div className="h-screen w-screen">
-            <Navbar />
+            {redesignEnabled ? <NavbarRedesign /> : <Navbar />}
             {children}
           </div>
           <Toaster position="bottom-right" />

--- a/next-client/src/components/navbar/FrontFacingNavbar.tsx
+++ b/next-client/src/components/navbar/FrontFacingNavbar.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Button } from "@/components/elements";
+import { Row } from "@/components/layout";
+import {
+  FrontFacingHomeLink,
+  FrontFacingNavLink,
+  RedesignLogo,
+  RedesignMobileMenu,
+  VerticalDivider,
+} from "./components/RedesignNavbarItems";
+
+const FRONT_FACING_MOBILE_LINKS = [
+  { href: "/product", label: "Product" },
+  { href: "/pricing", label: "Pricing" },
+  { href: "/about", label: "About" },
+  { href: "https://github.com/aIObjectives/tttc-light-js", label: "Github" },
+];
+
+const LoginButton = dynamic(() => import("./components/LoginButton"), {
+  ssr: false,
+  loading: () => (
+    <Button disabled className="min-w-[80px] h-10 rounded-full">
+      ...
+    </Button>
+  ),
+});
+
+export default function FrontFacingNavbar() {
+  return (
+    <Row
+      gap={6}
+      className="px-6 items-center justify-between h-16 border-b shadow-xs w-screen z-80 relative bg-white dark:bg-background"
+      data-navbar
+    >
+      <Row gap={2} className="items-center">
+        <RedesignMobileMenu links={FRONT_FACING_MOBILE_LINKS} />
+        <RedesignLogo />
+      </Row>
+      <Row gap={7} className="items-center">
+        <Row gap={7} className="items-center hidden md:flex">
+          <FrontFacingNavLink href="/product" label="Product" />
+          <FrontFacingNavLink href="/pricing" label="Pricing" />
+          <FrontFacingNavLink href="/about" label="About" />
+          <FrontFacingNavLink
+            href="https://github.com/aIObjectives/tttc-light-js"
+            label="Github"
+          />
+          <FrontFacingHomeLink />
+        </Row>
+        <VerticalDivider />
+        <LoginButton hideAppNavItems />
+      </Row>
+    </Row>
+  );
+}

--- a/next-client/src/components/navbar/NavbarRedesign.tsx
+++ b/next-client/src/components/navbar/NavbarRedesign.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import FrontFacingNavbar from "./FrontFacingNavbar";
+import UserFacingNavbar from "./UserFacingNavbar";
+
+// Routes that show the marketing / front-facing menu. Everything else gets the
+// user-facing (app) menu. New marketing pages added later (e.g. /privacy) should
+// be added here.
+const FRONT_FACING_ROUTES = ["/", "/about", "/safety", "/product", "/pricing"];
+
+function isFrontFacing(pathname: string | null): boolean {
+  if (!pathname) return true;
+  return FRONT_FACING_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+}
+
+export default function NavbarRedesign() {
+  const pathname = usePathname();
+  return isFrontFacing(pathname) ? <FrontFacingNavbar /> : <UserFacingNavbar />;
+}

--- a/next-client/src/components/navbar/NavbarRedesign.tsx
+++ b/next-client/src/components/navbar/NavbarRedesign.tsx
@@ -7,7 +7,14 @@ import UserFacingNavbar from "./UserFacingNavbar";
 // Routes that show the marketing / front-facing menu. Everything else gets the
 // user-facing (app) menu. New marketing pages added later (e.g. /privacy) should
 // be added here.
-const FRONT_FACING_ROUTES = ["/", "/about", "/safety", "/product", "/pricing"];
+const FRONT_FACING_ROUTES = [
+  "/",
+  "/about",
+  "/safety",
+  "/product",
+  "/pricing",
+  "/help",
+];
 
 function isFrontFacing(pathname: string | null): boolean {
   if (!pathname) return true;

--- a/next-client/src/components/navbar/UserFacingNavbar.tsx
+++ b/next-client/src/components/navbar/UserFacingNavbar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useMemo } from "react";
+import dynamic from "next/dynamic";
+import { Button } from "@/components/elements";
+import { Row } from "@/components/layout";
+import { useFeatureFlagQuery } from "@/lib/query/useFeatureFlagQuery";
+import { useUserQuery } from "@/lib/query/useUserQuery";
+import {
+  RedesignLogo,
+  RedesignMobileMenu,
+  ReportsButton,
+  StudiesButton,
+  VerticalDivider,
+} from "./components/RedesignNavbarItems";
+
+const LoginButton = dynamic(() => import("./components/LoginButton"), {
+  ssr: false,
+  loading: () => (
+    <Button disabled className="min-w-[80px] h-10 rounded-full">
+      ...
+    </Button>
+  ),
+});
+
+export default function UserFacingNavbar() {
+  const { user } = useUserQuery();
+  // Match the same study-access gating the old dropdown used so visibility
+  // doesn't change — we're only moving the link, not the gate.
+  const flagContext = useMemo(
+    () => (user?.uid ? { userId: user.uid } : undefined),
+    [user?.uid],
+  );
+  const { enabled: studiesEnabled } = useFeatureFlagQuery(
+    "elicitation_enabled",
+    flagContext,
+  );
+
+  const mobileLinks = [
+    ...(studiesEnabled ? [{ href: "/studies", label: "Studies" }] : []),
+    { href: "/my-reports", label: "Reports" },
+  ];
+
+  return (
+    <Row
+      gap={6}
+      className="px-6 items-center justify-between h-16 border-b shadow-xs w-screen z-80 relative bg-white dark:bg-background"
+      data-navbar
+    >
+      <Row gap={2} className="items-center">
+        <RedesignMobileMenu links={mobileLinks} />
+        <RedesignLogo />
+      </Row>
+      <Row gap={7} className="items-center">
+        <Row gap={3} className="items-center hidden md:flex">
+          {studiesEnabled && <StudiesButton />}
+          <ReportsButton />
+        </Row>
+        <VerticalDivider />
+        <LoginButton hideAppNavItems />
+      </Row>
+    </Row>
+  );
+}

--- a/next-client/src/components/navbar/UserFacingNavbar.tsx
+++ b/next-client/src/components/navbar/UserFacingNavbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo } from "react";
 import dynamic from "next/dynamic";
+import { useMemo } from "react";
 import { Button } from "@/components/elements";
 import { Row } from "@/components/layout";
 import { useFeatureFlagQuery } from "@/lib/query/useFeatureFlagQuery";

--- a/next-client/src/components/navbar/components/LoginButton.tsx
+++ b/next-client/src/components/navbar/components/LoginButton.tsx
@@ -111,7 +111,15 @@ const recordProfileSetupComplete = () => {
   localStorage.setItem(PROFILE_SETUP_KEY, JSON.stringify(updated));
 };
 
-export default function LoginButton() {
+interface LoginButtonProps {
+  // When true, omits the Reports/Studies items from the avatar dropdown.
+  // Used by the redesigned navbar where these are top-level nav items instead.
+  hideAppNavItems?: boolean;
+}
+
+export default function LoginButton({
+  hideAppNavItems = false,
+}: LoginButtonProps = {}) {
   const { user, loading, error } = useUserQuery();
   const flagContext = useMemo(
     () => (user?.uid ? { userId: user.uid } : undefined),
@@ -294,13 +302,17 @@ export default function LoginButton() {
             </Avatar>
           </DropdownMenuTrigger>
           <DropdownMenuContent sideOffset={20}>
-            <Link href={"/my-reports"}>
-              <DropdownMenuItem>Reports</DropdownMenuItem>
-            </Link>
-            {studiesEnabled && (
-              <Link href={"/studies"}>
-                <DropdownMenuItem>Studies</DropdownMenuItem>
-              </Link>
+            {!hideAppNavItems && (
+              <>
+                <Link href={"/my-reports"}>
+                  <DropdownMenuItem>Reports</DropdownMenuItem>
+                </Link>
+                {studiesEnabled && (
+                  <Link href={"/studies"}>
+                    <DropdownMenuItem>Studies</DropdownMenuItem>
+                  </Link>
+                )}
+              </>
             )}
             <DropdownMenuItem onClick={handleSignOut}>
               Sign out

--- a/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
+++ b/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
@@ -62,7 +62,8 @@ function AppNavButton({
   matchPrefix: string;
 }) {
   const pathname = usePathname();
-  const isActive = pathname === matchPrefix || pathname.startsWith(`${matchPrefix}/`);
+  const isActive =
+    pathname === matchPrefix || pathname.startsWith(`${matchPrefix}/`);
   return (
     <Button
       asChild
@@ -75,12 +76,18 @@ function AppNavButton({
 }
 
 export function StudiesButton() {
-  return <AppNavButton href="/studies" label="Studies" matchPrefix="/studies" />;
+  return (
+    <AppNavButton href="/studies" label="Studies" matchPrefix="/studies" />
+  );
 }
 
 export function ReportsButton() {
   return (
-    <AppNavButton href="/my-reports" label="Reports" matchPrefix="/my-reports" />
+    <AppNavButton
+      href="/my-reports"
+      label="Reports"
+      matchPrefix="/my-reports"
+    />
   );
 }
 

--- a/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
+++ b/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import Icons from "@/assets/icons";
+import {
+  Button,
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/elements";
+import { Col } from "@/components/layout";
+import { useUserQuery } from "@/lib/query/useUserQuery";
+
+export function RedesignLogo() {
+  return (
+    <Link href="/" className="flex items-center gap-2" aria-label="Home">
+      <Icons.Logo className="inline-block" />
+      <Icons.TTTC className="inline-block" />
+    </Link>
+  );
+}
+
+export function FrontFacingNavLink({
+  href,
+  label,
+}: {
+  href: string;
+  label: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="font-medium text-[16px] leading-6 text-foreground hover:underline whitespace-nowrap"
+    >
+      {label}
+    </Link>
+  );
+}
+
+// "Home" link in the front-facing menu: logged-in → /my-reports; logged-out
+// → triggers the existing LoginButton sign-in dialog via the ?action=signin
+// query param that LoginButton already listens for.
+export function FrontFacingHomeLink() {
+  const { user, loading } = useUserQuery();
+  if (loading) return null;
+  const href = user ? "/my-reports" : "?action=signin";
+  return <FrontFacingNavLink href={href} label="Home" />;
+}
+
+// Buttons used in the user-facing (app) menu. Highlighted variant when the
+// current route matches.
+function AppNavButton({
+  href,
+  label,
+  matchPrefix,
+}: {
+  href: string;
+  label: string;
+  matchPrefix: string;
+}) {
+  const pathname = usePathname();
+  const isActive = pathname === matchPrefix || pathname.startsWith(`${matchPrefix}/`);
+  return (
+    <Button
+      asChild
+      variant={isActive ? "secondary" : "outline"}
+      className="h-10 px-4 py-2 rounded-md font-medium text-[14px]"
+    >
+      <Link href={href}>{label}</Link>
+    </Button>
+  );
+}
+
+export function StudiesButton() {
+  return <AppNavButton href="/studies" label="Studies" matchPrefix="/studies" />;
+}
+
+export function ReportsButton() {
+  return (
+    <AppNavButton href="/my-reports" label="Reports" matchPrefix="/my-reports" />
+  );
+}
+
+export function VerticalDivider() {
+  return <div className="bg-border h-[25px] w-px" aria-hidden />;
+}
+
+type MobileLink = { href: string; label: string };
+
+export function RedesignMobileMenu({ links }: { links: MobileLink[] }) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <Sheet modal={false} open={isOpen} onOpenChange={setIsOpen}>
+      <SheetTrigger asChild className="md:hidden">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-10"
+          aria-label={isOpen ? "Close menu" : "Open menu"}
+        >
+          {isOpen ? (
+            <Icons.X className="size-6" />
+          ) : (
+            <Icons.Menu className="size-6" />
+          )}
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="bottom"
+        className="h-[90vh] p-6 pt-8"
+        aria-describedby={undefined}
+        hideCloseButton
+      >
+        <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+        <Col className="h-full">
+          {links.map((link) => (
+            <Link
+              key={link.href + link.label}
+              href={link.href}
+              onClick={() => setIsOpen(false)}
+              className="py-2 px-3 min-h-[44px] flex items-center w-full rounded-md hover:bg-accent hover:text-primary"
+            >
+              <p>{link.label}</p>
+            </Link>
+          ))}
+        </Col>
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the single Navbar with a route-aware `NavbarRedesign` that renders one of two variants based on the current pathname.

- **FrontFacingNavbar** (marketing routes: `/`, `/about`, `/safety`, `/product`, `/pricing`)
  - Logo · Product · Pricing · About · Github · Home · divider · LoginButton
  - "Home" → `/my-reports` when logged in, opens sign-in dialog (`?action=signin`) when logged out
  - Product and Pricing routes don't exist yet (future tickets) — links will 404 until those pages land
- **UserFacingNavbar** (app routes: `/my-reports`, `/studies`, `/create`, `/report/*`, `/elicitation/*`, `/help`)
  - Logo · Studies (gated by `elicitation_enabled`, same gate the old dropdown used) · Reports · divider · avatar
  - Active route is highlighted

`LoginButton` gains a `hideAppNavItems` prop that drops the now-redundant Reports/Studies items from the avatar dropdown. Defaults to false so the old Navbar's behavior is unchanged.

Mounted at `app/layout.tsx` behind the `website-redesign` flag using the cookie distinct_id reader from T3C-1188. Flag off → old Navbar; flag on → new.

Mobile uses a basic Sheet-based hamburger since no Figma mobile design exists.

## Linear

[T3C-1155](https://linear.app/aoi/issue/T3C-1155) (Menu Bar Not Logged In)
[T3C-1156](https://linear.app/aoi/issue/T3C-1156) (Menu Bar Logged In)

## Design references

- Front-facing menu: Figma node `11107-843`
- User-facing menu: Figma node `10808-47733`

## Test plan

- [ ] PR preview deploy uses `LOCAL_FLAGS={"website-redesign": true}` — open the preview URL and confirm:
  - Front-facing menu appears on `/`, `/about`, `/safety`
  - User-facing menu appears on `/my-reports`, `/create` (sign in first)
  - "Home" link in front-facing menu opens sign-in dialog when logged out
  - "Home" link in front-facing menu navigates to `/my-reports` when logged in
  - Avatar dropdown when logged in shows only "Sign out" (no Reports/Studies — those are now top-level)
  - Studies button only shows for users with `elicitation_enabled`
  - Active state highlight on Studies/Reports button matches current page
  - Mobile hamburger opens a sheet with the menu's links
- [ ] On `main` (flag off) the old Navbar is unaffected

## Known limitations / follow-ups

- Avatar styling not yet matched to Figma's pink circle (`#f34987` background with `#d32570` border, white initial). Currently uses ShadCN default Avatar. Can be styled in a follow-up after visual review.
- Mobile design improvised — would benefit from a real Figma mobile spec.