### PR TITLE
Add /product page (flag-gated)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -285,7 +285,9 @@
     "peacebuilding",
     "governorates",
     "Inverurie",
-    "Runbook"
+    "Runbook",
+    "reimagines",
+    "controversiality"
   ],
   "ignorePaths": [
     "node_modules",

--- a/next-client/src/app/product/page.tsx
+++ b/next-client/src/app/product/page.tsx
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+import ProductRedesign from "@/components/product/ProductRedesign";
+import { serverSideAnalyticsClient } from "@/lib/analytics/serverSideAnalytics";
+import {
+  initializeFeatureFlags,
+  isFeatureEnabled,
+} from "@/lib/feature-flags/featureFlags.server";
+import { getPostHogDistinctId } from "@/lib/feature-flags/getPostHogDistinctId";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProductPage() {
+  initializeFeatureFlags();
+  const distinctId = await getPostHogDistinctId();
+  const redesignEnabled = await isFeatureEnabled("website-redesign", {
+    userId: distinctId,
+  });
+
+  if (!redesignEnabled) {
+    notFound();
+  }
+
+  const analytics = await serverSideAnalyticsClient();
+  await analytics.page("Product");
+
+  return <ProductRedesign />;
+}

--- a/next-client/src/components/product/ProductRedesign.tsx
+++ b/next-client/src/components/product/ProductRedesign.tsx
@@ -225,24 +225,10 @@ function HowSurveysWork() {
             will notify the participant when the survey is over.
           </li>
           <li>
-            <strong>Follow-up mode:</strong> This mode is used to conduct
-            semi-structured, adaptive surveys that act more like traditional
-            interviews. Instead of moving straight through the questions you
-            provide, T3C asks follow-up questions.
-            <ul className="list-disc ml-8 mt-2">
-              <li>
-                <strong>How it works:</strong> T3C keeps the last 30 exchanges
-                to provide context for follow-up questions. After a participant
-                responds, T3C consults a bank of follow-up questions and selects
-                the most appropriate one given the context, or is prompted to
-                generate a new question if none of the existing ones are
-                suitable. It replaces placeholder variables in the follow-up
-                questions with specific content, e.g., &ldquo;Tell me more about
-                X&rdquo; becomes &ldquo;Tell me more about the weather where you
-                live.&rdquo; After asking the follow-up question, T3C moves on
-                to the next structured question.
-              </li>
-            </ul>
+            <strong>Follow-up mode:</strong> T3C asks follow-up questions after
+            each survey question, eliciting explanations for what people say.
+            For example, &ldquo;Tell me more about that — can you give me an
+            example of when that happened?&rdquo;
           </li>
         </ul>
         <p className="mb-3">

--- a/next-client/src/components/product/ProductRedesign.tsx
+++ b/next-client/src/components/product/ProductRedesign.tsx
@@ -31,14 +31,13 @@ function IntroSection() {
   return (
     <section className="px-8 lg:px-28 pb-8">
       <p className="text-xl text-muted-foreground leading-[31px]">
-        Talk to the City (T3C) is an{" "}
-        <strong>open-source AI tool</strong> that reimagines how communities,
-        institutions, and decision-makers gather and act on public input. T3C
-        allows you to design and launch{" "}
+        Talk to the City (T3C) is an <strong>open-source AI tool</strong> that
+        reimagines how communities, institutions, and decision-makers gather and
+        act on public input. T3C allows you to design and launch{" "}
         <strong>conversational AI surveys</strong> to engage diverse groups at
-        scale. Then, T3C helps you explore the results, distilling
-        conversations into <strong>interactive reports</strong> that highlight
-        themes and link every insight back to real participant quotes.
+        scale. Then, T3C helps you explore the results, distilling conversations
+        into <strong>interactive reports</strong> that highlight themes and link
+        every insight back to real participant quotes.
       </p>
     </section>
   );
@@ -222,8 +221,8 @@ function HowSurveysWork() {
           </li>
           <li>
             <strong>Survey mode:</strong> T3C works its way through the set of
-            survey questions you provide without asking follow-up questions.
-            T3C will notify the participant when the survey is over.
+            survey questions you provide without asking follow-up questions. T3C
+            will notify the participant when the survey is over.
           </li>
           <li>
             <strong>Follow-up mode:</strong> This mode is used to conduct
@@ -234,14 +233,14 @@ function HowSurveysWork() {
               <li>
                 <strong>How it works:</strong> T3C keeps the last 30 exchanges
                 to provide context for follow-up questions. After a participant
-                responds, T3C consults a bank of follow-up questions and
-                selects the most appropriate one given the context, or is
-                prompted to generate a new question if none of the existing
-                ones are suitable. It replaces placeholder variables in the
-                follow-up questions with specific content, e.g., &ldquo;Tell me
-                more about X&rdquo; becomes &ldquo;Tell me more about the
-                weather where you live.&rdquo; After asking the follow-up
-                question, T3C moves on to the next structured question.
+                responds, T3C consults a bank of follow-up questions and selects
+                the most appropriate one given the context, or is prompted to
+                generate a new question if none of the existing ones are
+                suitable. It replaces placeholder variables in the follow-up
+                questions with specific content, e.g., &ldquo;Tell me more about
+                X&rdquo; becomes &ldquo;Tell me more about the weather where you
+                live.&rdquo; After asking the follow-up question, T3C moves on
+                to the next structured question.
               </li>
             </ul>
           </li>
@@ -252,15 +251,15 @@ function HowSurveysWork() {
           participant, T3C can select similar and dissimilar claims across the
           collected data and present them for discussion. The way claims are
           presented, the claims themselves and the style with which the bot
-          prompts reflection can all be customized. Currently, deliberative
-          mode is not available in self-service; please reach out if you are
+          prompts reflection can all be customized. Currently, deliberative mode
+          is not available in self-service; please reach out if you are
           interested.
         </p>
         <p className="font-medium mb-2">Text, voice and language support</p>
         <p className="mb-3">
-          All modes accept voice messages. T3C can also be configured to
-          operate in different languages and is prompted to ask questions in
-          the participant&apos;s language if detected.
+          All modes accept voice messages. T3C can also be configured to operate
+          in different languages and is prompted to ask questions in the
+          participant&apos;s language if detected.
         </p>
         <p className="font-medium mb-2">FAQs</p>
         <p>

--- a/next-client/src/components/product/ProductRedesign.tsx
+++ b/next-client/src/components/product/ProductRedesign.tsx
@@ -211,7 +211,7 @@ function HowSurveysWork() {
           conversational survey through WhatsApp. T3C can operate in three
           different modes:
         </p>
-        <ul className="list-disc ml-8 space-y-3 mb-3">
+        <ul className="list-disc ml-8 space-y-4 mb-6">
           <li>
             <strong>Listening mode:</strong> T3C opens with an initial prompt,
             then listens to the participant, providing brief responses
@@ -255,13 +255,13 @@ function HowSurveysWork() {
           is not available in self-service; please reach out if you are
           interested.
         </p>
-        <p className="font-medium mb-2">Text, voice and language support</p>
+        <p className="font-bold mt-6 mb-3">Text, voice and language support</p>
         <p className="mb-3">
           All modes accept voice messages. T3C can also be configured to operate
           in different languages and is prompted to ask questions in the
           participant&apos;s language if detected.
         </p>
-        <p className="font-medium mb-2">FAQs</p>
+        <p className="font-bold mt-6 mb-3">FAQs</p>
         <p>
           We answer FAQs about data collection{" "}
           <Link href="/about" className="text-indigo-600 hover:underline">
@@ -290,12 +290,12 @@ function HowReportsWork() {
           modify the prompts used to create reports by looking under
           &ldquo;Advanced Settings&rdquo; on the report creator page.
         </p>
-        <p className="font-medium mb-2">Report access</p>
+        <p className="font-bold mt-6 mb-3">Report access</p>
         <p className="mb-3">
           Reports can be kept for your eyes only or made public to anybody who
           has the exact URL.
         </p>
-        <p className="font-medium mb-2">Experimental features</p>
+        <p className="font-bold mt-6 mb-3">Experimental features</p>
         <p className="mb-3">
           We have a few experimental features for you to try, including ranking
           claims by controversiality and identifying how constructive or
@@ -303,7 +303,7 @@ function HowReportsWork() {
           snippets, but this requires some pre-processing; if you can&apos;t
           figure it out from our Github please reach out and we will help you.
         </p>
-        <p className="font-medium mb-2">FAQs</p>
+        <p className="font-bold mt-6 mb-3">FAQs</p>
         <p>
           We answer FAQs about reports{" "}
           <Link href="/about" className="text-indigo-600 hover:underline">

--- a/next-client/src/components/product/ProductRedesign.tsx
+++ b/next-client/src/components/product/ProductRedesign.tsx
@@ -285,9 +285,9 @@ function HowReportsWork() {
         <p className="mb-3">
           We use Large Language Models (LLMs) to extract themes from your data,
           summarize specific claims and link those claims back to exact quotes.
-          We create an interactive report from the results, combining all
-          scales of analysis, and store for you on the talktothe.city site. You
-          can modify the prompts used to create reports by looking under
+          We create an interactive report from the results, combining all scales
+          of analysis, and store for you on the talktothe.city site. You can
+          modify the prompts used to create reports by looking under
           &ldquo;Advanced Settings&rdquo; on the report creator page.
         </p>
         <p className="font-medium mb-2">Report access</p>

--- a/next-client/src/components/product/ProductRedesign.tsx
+++ b/next-client/src/components/product/ProductRedesign.tsx
@@ -19,7 +19,7 @@ export default function ProductRedesign() {
 
 function HeroSection() {
   return (
-    <section className="px-8 lg:px-28 pt-16 pb-8">
+    <section className="max-w-7xl mx-auto px-8 lg:px-28 pt-16 pb-8">
       <h1 className="text-5xl lg:text-[96px] font-medium tracking-tight leading-tight text-center">
         Talk to the [<span className="text-indigo-600"> everyone </span>]
       </h1>
@@ -29,8 +29,8 @@ function HeroSection() {
 
 function IntroSection() {
   return (
-    <section className="px-8 lg:px-28 pb-8">
-      <p className="text-xl text-muted-foreground leading-[31px]">
+    <section className="max-w-7xl mx-auto px-8 lg:px-28 pb-8">
+      <p className="text-xl text-foreground leading-[31px]">
         Talk to the City (T3C) is an <strong>open-source AI tool</strong> that
         reimagines how communities, institutions, and decision-makers gather and
         act on public input. T3C allows you to design and launch{" "}
@@ -80,9 +80,9 @@ function AudienceCard({
 
 function WhoT3CIsFor() {
   return (
-    <section className="px-8 lg:px-28 pb-12">
+    <section className="max-w-7xl mx-auto px-8 lg:px-28 pb-12">
       <SectionHeading>Who T3C is great for</SectionHeading>
-      <p className="text-xl text-muted-foreground leading-[31px] mb-8">
+      <p className="text-xl text-foreground leading-[31px] mb-8">
         T3C is ideal for people who need to collect richer data than surveys
         allow, at bigger scales than is possible through traditional interviews.
         We&apos;re great for quickly understanding many diverse perspectives,
@@ -139,7 +139,7 @@ function WhoT3CIsFor() {
 
 function WhatT3CDoes() {
   return (
-    <section className="px-8 lg:px-28 pb-12">
+    <section className="max-w-7xl mx-auto px-8 lg:px-28 pb-12">
       <SectionHeading>What T3C does</SectionHeading>
       <div className="bg-theme_violet-accent rounded-3xl p-8 max-w-5xl mx-auto">
         <div className="relative w-full aspect-video">
@@ -158,10 +158,10 @@ function WhatT3CDoes() {
 
 function ReadyToGetStarted() {
   return (
-    <section className="px-8 lg:px-28 py-16 flex justify-center">
+    <section className="max-w-7xl mx-auto px-8 lg:px-28 py-16 flex justify-center">
       <Link
         href="/pricing"
-        className="bg-white border border-border rounded-[28px] w-full max-w-[625px] py-12 flex items-center justify-center text-indigo-600 text-4xl lg:text-5xl font-medium hover:bg-indigo-50 transition-colors"
+        className="bg-theme_violet-accent rounded-[28px] w-full max-w-[625px] py-12 flex items-center justify-center text-indigo-600 text-4xl lg:text-5xl font-medium hover:opacity-90 transition-opacity"
       >
         Ready to get started?
       </Link>
@@ -184,17 +184,17 @@ function CollapsibleBubble({
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
         aria-expanded={isOpen}
-        className="w-full text-left border border-slate-500 rounded-[27px] px-8 py-5 flex items-center justify-between bg-transparent cursor-pointer hover:bg-slate-50 transition-colors"
+        className="w-full text-left bg-theme_violet-accent rounded-[27px] px-8 py-5 flex items-center justify-between cursor-pointer hover:opacity-90 transition-opacity"
       >
         <span className="text-2xl font-semibold tracking-tight text-foreground">
           {title}
         </span>
-        <span aria-hidden className="text-2xl text-muted-foreground">
+        <span aria-hidden className="text-2xl text-foreground">
           {isOpen ? "–" : "+"}
         </span>
       </button>
       {isOpen && (
-        <div className="px-8 pt-6 text-xl text-muted-foreground leading-[31px]">
+        <div className="px-8 pt-6 text-xl text-foreground leading-[31px] [&_p]:text-xl">
           {children}
         </div>
       )}
@@ -204,7 +204,7 @@ function CollapsibleBubble({
 
 function HowSurveysWork() {
   return (
-    <section className="px-8 lg:px-28 pb-8">
+    <section className="max-w-7xl mx-auto px-8 lg:px-28 pb-8">
       <CollapsibleBubble title="How conversational surveys work">
         <p className="mb-3">
           You can use our study creator to design and launch an LLM-powered
@@ -280,7 +280,7 @@ function HowSurveysWork() {
 
 function HowReportsWork() {
   return (
-    <section className="px-8 lg:px-28 pb-16">
+    <section className="max-w-7xl mx-auto px-8 lg:px-28 pb-16">
       <CollapsibleBubble title="How reports work">
         <p className="mb-3">
           We use Large Language Models (LLMs) to extract themes from your data,

--- a/next-client/src/components/product/ProductRedesign.tsx
+++ b/next-client/src/components/product/ProductRedesign.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+export default function ProductRedesign() {
+  return (
+    <div className="overflow-x-hidden bg-white">
+      <HeroSection />
+      <IntroSection />
+      <WhoT3CIsFor />
+      <WhatT3CDoes />
+      <ReadyToGetStarted />
+      <HowSurveysWork />
+      <HowReportsWork />
+    </div>
+  );
+}
+
+function HeroSection() {
+  return (
+    <section className="px-8 lg:px-28 pt-16 pb-8">
+      <h1 className="text-5xl lg:text-[96px] font-medium tracking-tight leading-tight text-center">
+        Talk to the [<span className="text-indigo-600"> everyone </span>]
+      </h1>
+    </section>
+  );
+}
+
+function IntroSection() {
+  return (
+    <section className="px-8 lg:px-28 pb-8">
+      <p className="text-xl text-muted-foreground leading-[31px]">
+        Talk to the City (T3C) is an{" "}
+        <strong>open-source AI tool</strong> that reimagines how communities,
+        institutions, and decision-makers gather and act on public input. T3C
+        allows you to design and launch{" "}
+        <strong>conversational AI surveys</strong> to engage diverse groups at
+        scale. Then, T3C helps you explore the results, distilling
+        conversations into <strong>interactive reports</strong> that highlight
+        themes and link every insight back to real participant quotes.
+      </p>
+    </section>
+  );
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-3xl font-semibold tracking-tight leading-9 mb-6">
+      {children}
+    </h2>
+  );
+}
+
+function AudienceCard({
+  title,
+  borderColor,
+  bgColor,
+  items,
+}: {
+  title: string;
+  borderColor: string;
+  bgColor: string;
+  items: string[];
+}) {
+  return (
+    <div
+      className={`flex flex-col gap-3 border rounded-md p-4 ${borderColor} ${bgColor}`}
+    >
+      <p className="font-medium leading-6">{title}</p>
+      <ul className="list-disc ml-6 space-y-1">
+        {items.map((item) => (
+          <li key={item} className="leading-[26px]">
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function WhoT3CIsFor() {
+  return (
+    <section className="px-8 lg:px-28 pb-12">
+      <SectionHeading>Who T3C is great for</SectionHeading>
+      <p className="text-xl text-muted-foreground leading-[31px] mb-8">
+        T3C is ideal for people who need to collect richer data than surveys
+        allow, at bigger scales than is possible through traditional interviews.
+        We&apos;re great for quickly understanding many diverse perspectives,
+        from collecting student experiences across a semester to capturing the
+        local context of why social programs succeed and fail across many
+        implementations. Our reports are perfect for grounding discussion among
+        communities, organizations and decision-makers.
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-5xl mx-auto">
+        <AudienceCard
+          title="Communities and policy-makers"
+          borderColor="border-theme_violet"
+          bgColor="bg-theme_violet-accent"
+          items={[
+            "Raise topics for deliberation",
+            "Identify points of agreement and disagreement",
+            "Ground discussion in real voices",
+            "Collect local knowledge to shape policy and programs",
+          ]}
+        />
+        <AudienceCard
+          title="Mission-driven organizations"
+          borderColor="border-theme_blueSea"
+          bgColor="bg-theme_blueSea-accent"
+          items={[
+            "Conduct needs assessments",
+            "Receive feedback in real time from staff and program participants",
+            "Track hard-to-quantify outcomes",
+          ]}
+        />
+        <AudienceCard
+          title="Funders"
+          borderColor="border-theme_blueSky"
+          bgColor="bg-theme_blueSky-accent"
+          items={[
+            "Collect expertise for field-building and scoping exercises",
+            "Stay aware of grantee activities",
+            "Verify bottlenecks and anticipate transition challenges",
+          ]}
+        />
+        <AudienceCard
+          title="Event hosts"
+          borderColor="border-theme_greenLime"
+          bgColor="bg-theme_greenLime-accent"
+          items={[
+            "Collect real time ideas and reactions from workshop and conference participants",
+            "Understand experiences across multiple events like university classes",
+          ]}
+        />
+      </div>
+    </section>
+  );
+}
+
+function WhatT3CDoes() {
+  return (
+    <section className="px-8 lg:px-28 pb-12">
+      <SectionHeading>What T3C does</SectionHeading>
+      <div className="bg-theme_violet-accent rounded-3xl p-8 max-w-5xl mx-auto">
+        <div className="relative w-full aspect-video">
+          <iframe
+            src="https://www.youtube.com/embed/M_lEuifm4IQ"
+            title="Talk to the City demo video"
+            className="absolute inset-0 w-full h-full rounded-lg"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ReadyToGetStarted() {
+  return (
+    <section className="px-8 lg:px-28 py-16 flex justify-center">
+      <Link
+        href="/pricing"
+        className="bg-white border border-border rounded-[28px] w-full max-w-[625px] py-12 flex items-center justify-center text-indigo-600 text-4xl lg:text-5xl font-medium hover:bg-indigo-50 transition-colors"
+      >
+        Ready to get started?
+      </Link>
+    </section>
+  );
+}
+
+// Click-to-expand bubble matching the Figma "How … works" sections.
+function CollapsibleBubble({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div className="mb-6">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+        className="w-full text-left border border-slate-500 rounded-[27px] px-8 py-5 flex items-center justify-between bg-transparent cursor-pointer hover:bg-slate-50 transition-colors"
+      >
+        <span className="text-2xl font-semibold tracking-tight text-foreground">
+          {title}
+        </span>
+        <span aria-hidden className="text-2xl text-muted-foreground">
+          {isOpen ? "–" : "+"}
+        </span>
+      </button>
+      {isOpen && (
+        <div className="px-8 pt-6 text-xl text-muted-foreground leading-[31px]">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HowSurveysWork() {
+  return (
+    <section className="px-8 lg:px-28 pb-8">
+      <CollapsibleBubble title="How conversational surveys work">
+        <p className="mb-3">
+          You can use our study creator to design and launch an LLM-powered
+          conversational survey through WhatsApp. T3C can operate in three
+          different modes:
+        </p>
+        <ul className="list-disc ml-8 space-y-3 mb-3">
+          <li>
+            <strong>Listening mode:</strong> T3C opens with an initial prompt,
+            then listens to the participant, providing brief responses
+            (&ldquo;Yes, I&apos;m here&rdquo;) but not asking questions or
+            steering the conversation. When the participant is done, they say
+            &ldquo;Finalize.&rdquo;
+          </li>
+          <li>
+            <strong>Survey mode:</strong> T3C works its way through the set of
+            survey questions you provide without asking follow-up questions.
+            T3C will notify the participant when the survey is over.
+          </li>
+          <li>
+            <strong>Follow-up mode:</strong> This mode is used to conduct
+            semi-structured, adaptive surveys that act more like traditional
+            interviews. Instead of moving straight through the questions you
+            provide, T3C asks follow-up questions.
+            <ul className="list-disc ml-8 mt-2">
+              <li>
+                <strong>How it works:</strong> T3C keeps the last 30 exchanges
+                to provide context for follow-up questions. After a participant
+                responds, T3C consults a bank of follow-up questions and
+                selects the most appropriate one given the context, or is
+                prompted to generate a new question if none of the existing
+                ones are suitable. It replaces placeholder variables in the
+                follow-up questions with specific content, e.g., &ldquo;Tell me
+                more about X&rdquo; becomes &ldquo;Tell me more about the
+                weather where you live.&rdquo; After asking the follow-up
+                question, T3C moves on to the next structured question.
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <p className="mb-3">
+          T3C can also support a deliberative mode that prompts participants to
+          reflect on their viewpoints in follow-up sessions. For each
+          participant, T3C can select similar and dissimilar claims across the
+          collected data and present them for discussion. The way claims are
+          presented, the claims themselves and the style with which the bot
+          prompts reflection can all be customized. Currently, deliberative
+          mode is not available in self-service; please reach out if you are
+          interested.
+        </p>
+        <p className="font-medium mb-2">Text, voice and language support</p>
+        <p className="mb-3">
+          All modes accept voice messages. T3C can also be configured to
+          operate in different languages and is prompted to ask questions in
+          the participant&apos;s language if detected.
+        </p>
+        <p className="font-medium mb-2">FAQs</p>
+        <p>
+          We answer FAQs about data collection{" "}
+          <Link href="/about" className="text-indigo-600 hover:underline">
+            here
+          </Link>{" "}
+          and provide information on security and privacy{" "}
+          <Link href="/safety" className="text-indigo-600 hover:underline">
+            here
+          </Link>
+          .
+        </p>
+      </CollapsibleBubble>
+    </section>
+  );
+}
+
+function HowReportsWork() {
+  return (
+    <section className="px-8 lg:px-28 pb-16">
+      <CollapsibleBubble title="How reports work">
+        <p className="mb-3">
+          We use Large Language Models (LLMs) to extract themes from your data,
+          summarize specific claims and link those claims back to exact quotes.
+          We create an interactive report from the results, combining all
+          scales of analysis, and store for you on the talktothe.city site. You
+          can modify the prompts used to create reports by looking under
+          &ldquo;Advanced Settings&rdquo; on the report creator page.
+        </p>
+        <p className="font-medium mb-2">Report access</p>
+        <p className="mb-3">
+          Reports can be kept for your eyes only or made public to anybody who
+          has the exact URL.
+        </p>
+        <p className="font-medium mb-2">Experimental features</p>
+        <p className="mb-3">
+          We have a few experimental features for you to try, including ranking
+          claims by controversiality and identifying how constructive or
+          divisive responses are. Reports can also include audio or video
+          snippets, but this requires some pre-processing; if you can&apos;t
+          figure it out from our Github please reach out and we will help you.
+        </p>
+        <p className="font-medium mb-2">FAQs</p>
+        <p>
+          We answer FAQs about reports{" "}
+          <Link href="/about" className="text-indigo-600 hover:underline">
+            here
+          </Link>{" "}
+          and provide information on the risks associated with using LLMs for
+          analysis{" "}
+          <Link href="/safety" className="text-indigo-600 hover:underline">
+            here
+          </Link>
+          .
+        </p>
+      </CollapsibleBubble>
+    </section>
+  );
+}

--- a/next-client/src/components/product/ProductRedesign.tsx
+++ b/next-client/src/components/product/ProductRedesign.tsx
@@ -194,7 +194,7 @@ function CollapsibleBubble({
         </span>
       </button>
       {isOpen && (
-        <div className="px-8 pt-6 text-xl text-foreground leading-[31px] [&_p]:text-xl">
+        <div className="px-8 pt-6 text-xl text-foreground leading-6 [&_p]:text-xl">
           {children}
         </div>
       )}


### PR DESCRIPTION
## Summary

New \`/product\` route under the \`website-redesign\` feature flag. Returns 404 when flag is off, renders \`ProductRedesign\` when on. Builds against Figma node [11121-10744](https://www.figma.com/design/u6EoCizYorXwIUuHcmmLtK/T3C-2.0?node-id=11121-10744).

## Sections

- **Hero**: "Talk to the [ everyone ]" with bracketed indigo word
- **Intro**: open-source AI tool paragraph
- **Who T3C is great for**: 2×2 grid of color-coded audience cards (Communities/Mission-driven/Funders/Event hosts) using theme_violet / blueSea / blueSky / greenLime
- **What T3C does**: YouTube demo video embed (\`M_lEuifm4IQ\`)
- **Ready to get started?**: Big CTA → \`/pricing\` (route doesn't exist yet — link will 404 until T3C-1148 lands)
- **How conversational surveys work**: Click-to-expand bubble with detailed survey-modes explanation. Inline FAQ links → \`/about\` (data collection FAQs) and \`/safety\` (privacy/security)
- **How reports work**: Click-to-expand bubble with report explanation. FAQ links → \`/about\` (report FAQs) and \`/safety\` (LLM risks)

## Notes

- Click-to-expand bubbles built inline (no ShadCN Accordion installed). One \`useState\` per bubble; both can be open simultaneously.
- Page lives at \`/product\` and is added to the front-facing route list in PR #680 (menu bar PR). When that PR merges, navigating to /product will get the front-facing nav.
- No mobile-specific Figma; layout uses standard responsive Tailwind breakpoints (md+).

## Test plan

- [ ] PR preview deploy includes \`LOCAL_FLAGS={"website-redesign": true}\` — visit \`/product\` on the preview URL and confirm:
  - All seven sections render
  - YouTube video plays in the embed
  - Four audience cards show with the right colors
  - "Ready to get started?" CTA renders and links to /pricing
  - The two "How … works" bubbles open/close when clicked
  - FAQ "here" links point to /about and /safety
- [ ] On a deploy without the flag (or with \`website-redesign: false\`), \`/product\` returns 404.