### PR TITLE
Redesign: text-foreground + width cap on Landing and Safety

### DIFF
--- a/next-client/src/components/landing/LandingRedesign.tsx
+++ b/next-client/src/components/landing/LandingRedesign.tsx
@@ -163,9 +163,7 @@ function TestimonialCard({
       />
       <div className="flex-1 border border-border rounded-lg shadow-md p-4">
         <div className="flex gap-3 items-start">
-          <span className="text-foreground text-xl shrink-0">
-            &ldquo;
-          </span>
+          <span className="text-foreground text-xl shrink-0">&ldquo;</span>
           <p className="text-foreground text-base leading-6">
             {quote}
             <br />

--- a/next-client/src/components/landing/LandingRedesign.tsx
+++ b/next-client/src/components/landing/LandingRedesign.tsx
@@ -163,10 +163,10 @@ function TestimonialCard({
       />
       <div className="flex-1 border border-border rounded-lg shadow-md p-4">
         <div className="flex gap-3 items-start">
-          <span className="text-muted-foreground text-xl shrink-0">
+          <span className="text-foreground text-xl shrink-0">
             &ldquo;
           </span>
-          <p className="text-muted-foreground text-base leading-6">
+          <p className="text-foreground text-base leading-6">
             {quote}
             <br />
             {attribution}

--- a/next-client/src/components/safety/SafetyRedesign.tsx
+++ b/next-client/src/components/safety/SafetyRedesign.tsx
@@ -9,7 +9,7 @@ export default function SafetyRedesign() {
 
 function HeroSection() {
   return (
-    <section className="px-8 lg:px-28 pt-16 pb-8">
+    <section className="max-w-7xl mx-auto px-8 lg:px-28 pt-16 pb-8">
       <h1 className="text-7xl lg:text-[96px] font-medium tracking-wide leading-tight mb-10">
         Understanding AI Risks
       </h1>
@@ -19,7 +19,7 @@ function HeroSection() {
 
 function ContentSection() {
   return (
-    <section className="px-8 lg:px-28 pb-16">
+    <section className="max-w-7xl mx-auto px-8 lg:px-28 pb-16">
       <IntroBlock />
       <MitigationsSection />
       <RemainingRisksSection />
@@ -31,7 +31,7 @@ function ContentSection() {
 function IntroBlock() {
   return (
     <div>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         Talk to the City uses Large Language Models (LLMs) to strengthen
         collective decision-making by transforming large-scale public input into
         actionable insights. Unlike traditional polling or commercial survey
@@ -40,7 +40,7 @@ function IntroBlock() {
         that matter most. Like all AI systems, LLMs have limitations and risks
         that users should understand.
       </p>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         LLMs excel at recognizing language patterns, identifying themes, and
         summarizing complex information. However, they are prediction machines,
         not truth machines. They generate text based on patterns they have
@@ -48,10 +48,10 @@ function IntroBlock() {
         plausible but is not grounded in source materials, it is called a
         &ldquo;hallucination.&rdquo;
       </p>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         In the context of summarizing large opinion datasets, this might mean:
       </p>
-      <ul className="list-disc text-xl font-normal text-muted-foreground leading-[31px] mb-10 ml-8 space-y-1 max-w-5xl">
+      <ul className="list-disc text-xl font-normal text-foreground leading-[31px] mb-10 ml-8 space-y-1 max-w-5xl">
         <li>
           <span className="font-medium">Invented claims:</span> Generating
           statements no participants actually made.
@@ -80,34 +80,34 @@ function MitigationsSection() {
       <h2 className="text-3xl font-semibold tracking-tight leading-9 mt-16 mb-4">
         How Talk to the City Mitigates Hallucinations
       </h2>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         We have built Talk to the City with multiple safeguards and validation
         steps into the processing pipeline to mitigate these risks.
       </p>
 
-      <h3 className="text-xl font-medium text-muted-foreground leading-[31px] mb-2">
+      <h3 className="text-xl font-medium text-foreground leading-[31px] mb-2">
         Claim Extraction with Constrained Output
       </h3>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         For each comment, the LLM extracts explicit claims and must link them to
         verbatim quotes from real people that support each claim. The LLM can
         only use topic and subtopic names generated during the initial
         extraction phase—no variations or new names are allowed.
       </p>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         Short comments (fewer than three words) are filtered out because they
         can cause the LLM to hallucinate by inventing missing details.
       </p>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         Each extracted claim in a Talk to the City report is directly traceable
         to real people&apos;s opinions. Clicking a claim reveals the exact
         supporting quotes and participants behind it to verify whether the
         summary is fair and accurate.
       </p>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         We also use automated tests to flag low-quality extractions:
       </p>
-      <ul className="list-disc text-xl font-normal text-muted-foreground leading-[31px] mb-10 ml-8 space-y-1 max-w-5xl">
+      <ul className="list-disc text-xl font-normal text-foreground leading-[31px] mb-10 ml-8 space-y-1 max-w-5xl">
         <li>
           Overly generic claims (&ldquo;communication is important&rdquo;)
         </li>
@@ -119,14 +119,14 @@ function MitigationsSection() {
         <li>Mismatched or incomplete quotes</li>
       </ul>
 
-      <h3 className="text-xl font-medium text-muted-foreground leading-[31px] mb-2">
+      <h3 className="text-xl font-medium text-foreground leading-[31px] mb-2">
         Transparency and Auditability
       </h3>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         Every report also includes a detailed audit log of all processing
         decisions, showing:
       </p>
-      <ul className="list-disc text-xl font-normal text-muted-foreground leading-[31px] mb-4 ml-8 space-y-1 max-w-5xl">
+      <ul className="list-disc text-xl font-normal text-foreground leading-[31px] mb-4 ml-8 space-y-1 max-w-5xl">
         <li>
           <span className="font-medium">Filtering:</span> Which comments were
           excluded (too short, etc) and why
@@ -144,7 +144,7 @@ function MitigationsSection() {
           versions, and configuration details
         </li>
       </ul>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-10">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-10">
         This enables full traceability. If you discover a possible hallucination
         or misclassification, please report it through{" "}
         <a
@@ -165,49 +165,49 @@ function RemainingRisksSection() {
       <h2 className="text-3xl font-semibold tracking-tight leading-9 mt-16 mb-4">
         Remaining Risks
       </h2>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         Despite our safeguards, some risks remain:
       </p>
 
-      <h3 className="text-xl font-medium text-muted-foreground leading-[31px] mb-2">
+      <h3 className="text-xl font-medium text-foreground leading-[31px] mb-2">
         Subtle Overgeneralization
       </h3>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         The AI might slightly exaggerate or reframe a sentiment. For example:
       </p>
-      <ul className="list-disc text-xl font-normal text-muted-foreground leading-[31px] mb-4 ml-8 space-y-1 max-w-5xl">
+      <ul className="list-disc text-xl font-normal text-foreground leading-[31px] mb-4 ml-8 space-y-1 max-w-5xl">
         <li>Comment: &ldquo;I&apos;m not sure about birds&rdquo;</li>
         <li>Claim: &ldquo;Birds are not ideal pets for everyone&rdquo;</li>
       </ul>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         The claim adds certainty not present in the original comment.
       </p>
 
-      <h3 className="text-xl font-medium text-muted-foreground leading-[31px] mb-2">
+      <h3 className="text-xl font-medium text-foreground leading-[31px] mb-2">
         Topic Sorting Ambiguity
       </h3>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         LLM topic sorting may differ from human intuition, occasionally merging
         or fragmenting categories in unexpected ways.
       </p>
 
-      <h3 className="text-xl font-medium text-muted-foreground leading-[31px] mb-2">
+      <h3 className="text-xl font-medium text-foreground leading-[31px] mb-2">
         Missing Edge Cases
       </h3>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         Niche or minority perspectives can be underrepresented or absorbed into
         broader themes.
       </p>
 
-      <h3 className="text-xl font-medium text-muted-foreground leading-[31px] mb-2">
+      <h3 className="text-xl font-medium text-foreground leading-[31px] mb-2">
         Bias Inheritance
       </h3>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-4">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-4">
         Because LLMs reflect patterns in their training data, they may reproduce
         cultural or societal biases in phrasing or emphasis. To make the most of
         your report, stay alert to two types of potential issues:
       </p>
-      <ol className="list-decimal text-xl font-normal text-muted-foreground leading-[31px] mb-4 ml-8 space-y-2 max-w-5xl">
+      <ol className="list-decimal text-xl font-normal text-foreground leading-[31px] mb-4 ml-8 space-y-2 max-w-5xl">
         <li>
           <span className="font-medium">AI Interpretation Limits:</span> These
           relate to how language models interpret or summarize text.
@@ -244,7 +244,7 @@ function HumanOversightSection() {
       <h2 className="text-3xl font-semibold tracking-tight leading-9 mt-16 mb-4">
         Human Oversight Matters
       </h2>
-      <p className="text-xl font-normal text-muted-foreground leading-[31px] max-w-5xl mb-10">
+      <p className="text-xl font-normal text-foreground leading-[31px] max-w-5xl mb-10">
         Think of Talk to the City as a highly capable research assistant: fast,
         consistent, and insightful, but still requiring human oversight and
         judgment. Use reports as a starting point for conversation, not the


### PR DESCRIPTION
## Summary

Two small consistency tweaks to the already-deployed Landing and Safety redesigned pages:

1. **Text color**: `text-muted-foreground` → `text-foreground` (legibility). Matches the same treatment now applied to About (PR #681) and Product (PR #682).
2. **Width cap**: wrap Safety's sections in `max-w-7xl mx-auto` so content stops at 1280px on wide monitors instead of stretching edge-to-edge.

## Why not also cap Landing?

The Landing page has its own per-section width strategy (subtitle at `max-w-2xl`, image at `max-w-5xl`, testimonials at `max-w-4xl`) and the `LogosGrid` at `lg` breakpoint is `4*320 + 3*4 = 1292px` wide — capping the section at `max-w-7xl` (1280px) would clip the rightmost logo. Left Landing alone for that reason.

## Test plan

- [ ] PR preview deploy includes `LOCAL_FLAGS={"website-redesign": true}` — open the preview URL and:
  - On `/` (Landing): testimonials quote text is now darker (foreground, not muted)
  - On `/safety`: all text is darker; on a wide monitor the content visibly stops at ~1280px wide rather than stretching