### PR TITLE
Post-launch mobile fixes

### DIFF
--- a/next-client/src/app/page.tsx
+++ b/next-client/src/app/page.tsx
@@ -25,7 +25,7 @@ export default async function HomePage() {
   return (
     <div>
       {redesignEnabled ? <LandingRedesign /> : <Landing />}
-      <Feedback />
+      <Feedback className="hidden md:block" />
     </div>
   );
 }

--- a/next-client/src/components/landing/LandingRedesign.tsx
+++ b/next-client/src/components/landing/LandingRedesign.tsx
@@ -14,7 +14,6 @@ const AUDIENCE_WORDS = [
   "community",
   "expert",
   "field",
-  "patient",
   "client",
   "partners",
   "grantee",
@@ -45,14 +44,17 @@ function HeroSection() {
   return (
     <section className="bg-white px-8 lg:px-20 py-16 text-center">
       <h1 className="text-5xl lg:text-7xl font-medium tracking-tight leading-tight mb-8">
-        Talk to the [
-        <span className="inline-grid justify-items-center">
-          <span className="invisible col-start-1 row-start-1">community</span>
-          <span className="col-start-1 row-start-1 text-indigo-600">
-            {AUDIENCE_WORDS[wordIndex]}
+        Talk to the{" "}
+        <span className="inline-block whitespace-nowrap">
+          [
+          <span className="inline-grid justify-items-center align-middle">
+            <span className="invisible col-start-1 row-start-1">community</span>
+            <span className="col-start-1 row-start-1 text-indigo-600">
+              {AUDIENCE_WORDS[wordIndex]}
+            </span>
           </span>
+          ]
         </span>
-        ]
       </h1>
       <p className="text-xl lg:text-2xl text-foreground max-w-2xl mx-auto mb-12 leading-relaxed">
         Capture human perspectives at any scale and generate insightful reports

--- a/next-client/src/components/myReports/MyReports.tsx
+++ b/next-client/src/components/myReports/MyReports.tsx
@@ -161,14 +161,9 @@ function YourReportsHeader({
   redesignEnabled = false,
 }: YourReportsHeaderProps) {
   return (
-    <Row
-      gap={4}
-      className="pt-8 w-full max-w-[896px] justify-between items-center"
-    >
-      <Col gap={2} className="justify-center">
-        <h3>{redesignEnabled ? "Reports" : "My reports"}</h3>
-      </Col>
-      <Row gap={2} className="items-center">
+    <div className="pt-8 w-full max-w-[896px] flex flex-col sm:flex-row gap-4 sm:justify-between sm:items-center">
+      <h3>{redesignEnabled ? "Reports" : "My reports"}</h3>
+      <Row gap={2} className="items-center flex-wrap">
         {redesignEnabled && (
           <Link href="/create">
             <Button size="sm">
@@ -252,7 +247,7 @@ function YourReportsHeader({
           </DropdownMenuContent>
         </DropdownMenu>
       </Row>
-    </Row>
+    </div>
   );
 }
 

--- a/next-client/src/components/navbar/FrontFacingNavbar.tsx
+++ b/next-client/src/components/navbar/FrontFacingNavbar.tsx
@@ -16,6 +16,7 @@ const FRONT_FACING_MOBILE_LINKS = [
   { href: "/workwithus", label: "Pricing" },
   { href: "/about", label: "About" },
   { href: "https://github.com/aIObjectives/tttc-light-js", label: "Github" },
+  { href: "/my-reports", label: "Home" },
 ];
 
 const LoginButton = dynamic(() => import("./components/LoginButton"), {
@@ -49,7 +50,7 @@ export default function FrontFacingNavbar() {
           />
           <FrontFacingHomeLink />
         </Row>
-        <VerticalDivider />
+        <VerticalDivider className="hidden md:block" />
         <LoginButton hideAppNavItems />
       </Row>
     </Row>

--- a/next-client/src/components/navbar/UserFacingNavbar.tsx
+++ b/next-client/src/components/navbar/UserFacingNavbar.tsx
@@ -43,7 +43,7 @@ export default function UserFacingNavbar() {
           <StudiesButton />
           <ReportsButton />
         </Row>
-        <VerticalDivider />
+        <VerticalDivider className="hidden md:block" />
         <LoginButton hideAppNavItems />
       </Row>
     </Row>

--- a/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
+++ b/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
@@ -91,8 +91,10 @@ export function ReportsButton() {
   );
 }
 
-export function VerticalDivider() {
-  return <div className="bg-border h-[25px] w-px" aria-hidden />;
+export function VerticalDivider({ className = "" }: { className?: string }) {
+  return (
+    <div className={`bg-border h-[25px] w-px ${className}`} aria-hidden />
+  );
 }
 
 type MobileLink = { href: string; label: string };
@@ -117,7 +119,7 @@ export function RedesignMobileMenu({ links }: { links: MobileLink[] }) {
       </SheetTrigger>
       <SheetContent
         side="bottom"
-        className="h-[90vh] p-6 pt-8"
+        className="h-[calc(100vh-5rem)] p-6 pt-8"
         aria-describedby={undefined}
         hideCloseButton
       >

--- a/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
+++ b/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
@@ -92,9 +92,7 @@ export function ReportsButton() {
 }
 
 export function VerticalDivider({ className = "" }: { className?: string }) {
-  return (
-    <div className={`bg-border h-[25px] w-px ${className}`} aria-hidden />
-  );
+  return <div className={`bg-border h-[25px] w-px ${className}`} aria-hidden />;
 }
 
 type MobileLink = { href: string; label: string };

--- a/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
+++ b/next-client/src/components/navbar/components/RedesignNavbarItems.tsx
@@ -117,7 +117,7 @@ export function RedesignMobileMenu({ links }: { links: MobileLink[] }) {
       </SheetTrigger>
       <SheetContent
         side="bottom"
-        className="h-[calc(100vh-5rem)] p-6 pt-8"
+        className="h-[80vh] p-6 pt-12"
         aria-describedby={undefined}
         hideCloseButton
       >

--- a/next-client/src/components/product/ProductRedesign.tsx
+++ b/next-client/src/components/product/ProductRedesign.tsx
@@ -21,7 +21,10 @@ function HeroSection() {
   return (
     <section className="max-w-7xl mx-auto px-8 lg:px-28 pt-16 pb-8">
       <h1 className="text-5xl lg:text-[96px] font-medium tracking-tight leading-tight text-center">
-        Talk to the [<span className="text-indigo-600"> everyone </span>]
+        Talk to the{" "}
+        <span className="whitespace-nowrap">
+          [<span className="text-indigo-600"> everyone </span>]
+        </span>
       </h1>
     </section>
   );
@@ -161,7 +164,7 @@ function ReadyToGetStarted() {
     <section className="max-w-7xl mx-auto px-8 lg:px-28 py-16 flex justify-center">
       <Link
         href="/workwithus"
-        className="bg-theme_violet-accent rounded-[28px] w-full max-w-[625px] py-12 flex items-center justify-center text-indigo-600 text-4xl lg:text-5xl font-medium hover:opacity-90 transition-opacity"
+        className="bg-theme_violet-accent rounded-[28px] w-full max-w-[625px] py-12 px-6 flex items-center justify-center text-center text-indigo-600 text-4xl lg:text-5xl font-medium hover:opacity-90 transition-opacity"
       >
         Ready to get started?
       </Link>


### PR DESCRIPTION
## Summary

Now that the redesign is live, mobile users surfaced a few issues. Small follow-up fixes:

1. **Hamburger sheet was being clipped by the navbar.** Changed sheet height from `h-[90vh]` to `h-[calc(100vh-5rem)]` so the sheet starts a comfortable distance below the 64px top bar.
2. **Mobile menu was missing 'Home'.** Added it to `FRONT_FACING_MOBILE_LINKS`; href is `/my-reports` so logged-out users land on the standard "please log in" view.
3. **Floating vertical divider on mobile.** The divider between the (now-collapsed) desktop nav row and the LoginButton looked like a stray vertical line. Hidden on mobile in both `FrontFacingNavbar` and `UserFacingNavbar`.
4. **'Talk to the [ ... ]' hero wrapped at the wrong place** (e.g. `Talk to the [` / `everyone ]`). Wrapped the bracket-and-word group in `whitespace-nowrap` on both `LandingRedesign` and `ProductRedesign`.
5. **'Ready to get started?' CTA text wasn't centered when it wrapped.** Added `text-center` and a bit of horizontal padding.
6. Trimmed the scrolling audience word list.

## Test plan

- [ ] PR preview deploy. On a mobile viewport (or browser devtools at <768px):
  - Tap the hamburger — full menu visible, not clipped at the top
  - Front-facing pages: hamburger lists Product / Pricing / About / Github / Home
  - No floating vertical line near the login button
  - Landing and Product heroes: 'Talk to the [...]' stays as one line per word
  - Product page CTA reads centered on narrow widths
- [ ] Desktop view is unchanged.

## Notes

Not addressing (per Allegra): the long-vertical opening quote next to multi-line testimonial text on Landing — flagged but deferred.