### PR TITLE
Never auto-merge Renovate PRs for scoped pnpm.overrides entries

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,6 +56,11 @@
       "description": "Group Firebase packages",
       "matchPackagePatterns": ["^firebase", "^@firebase/"],
       "groupName": "Firebase"
+    },
+    {
+      "description": "Never auto-merge pnpm scoped major-line overrides (pkg@N syntax in pnpm.overrides). Each entry pins a version for one specific major line in the dependency tree, so bumping the value across a major boundary can break API compatibility for whatever depends on that line. Needs manual review even for security alerts.",
+      "matchPackagePatterns": ["@[0-9]+(\\.[0-9]+)*$"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Renovate parses pnpm's scoped override syntax (`pkg@major`) as if it were a plain dependency name, and will happily bump the pinned version across major-version boundaries when it thinks it's applying a security fix.
- Two such PRs already auto-merged into `main` before this was caught: #705 collapsed `brace-expansion@1` from `1.1.18` to `5.0.9` (a 4-major jump), and #704 changed `@grpc/grpc-js@1.9` from `1.9.16` to `1.14.4`.
- These overrides are deliberately scoped per major line because different parts of the dependency tree resolve to different majors of the same package (e.g. `minimatch@3`/`glob@7` expect brace-expansion's v1 API). Collapsing a scoped override to a newer major can silently break whatever depends on that line's API shape.
- This adds a `packageRules` entry matching the `pkg@N` override syntax and sets `automerge: false` for it. Renovate will still open PRs (and still label them `security` for vulnerability alerts) so we keep visibility — they just require a quick manual review before merging instead of merging unattended.

## Test plan
- [x] `renovate-config-validator` passes on the updated `renovate.json`
- [x] Verified the pattern matches all 15 current scoped-override entries (ajv, bn.js, brace-expansion, form-data, @grpc/grpc-js, minimatch, picomatch, ws) and no ordinary package names
- [x] Disabled auto-merge on the two currently-open PRs following this same pattern (#706, #707) as a stopgap