### PR TITLE
Patch minimatch@3.1.5 for brace-expansion v5 compat, then re-secure the override

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
       "bn.js@4": "4.12.3",
       "bn.js@5": "5.2.5",
       "body-parser": "2.3.0",
-      "brace-expansion@1": "5.0.9",
+      "brace-expansion@1": "1.1.18",
       "brace-expansion@2": "2.1.4",
       "brace-expansion@5": "5.0.9",
       "diff": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
       "flat-cache": "^4.0.1",
       "@types/react": "^19.2.7",
       "@types/react-dom": "^19.2.3",
-
       "ajv@6": "6.14.0",
       "ajv@8": "8.20.0",
       "axios": "1.19.0",
@@ -80,7 +79,7 @@
       "bn.js@4": "4.12.3",
       "bn.js@5": "5.2.5",
       "body-parser": "2.3.0",
-      "brace-expansion@1": "1.1.18",
+      "brace-expansion@1": "5.0.9",
       "brace-expansion@2": "2.1.4",
       "brace-expansion@5": "5.0.9",
       "diff": "4.0.4",
@@ -121,6 +120,9 @@
       "websocket-driver": "0.7.5",
       "ws@8": "8.21.0",
       "yaml": "2.9.0"
+    },
+    "patchedDependencies": {
+      "minimatch@3.1.5": "patches/minimatch@3.1.5.patch"
     }
   }
 }

--- a/patches/minimatch@3.1.5.patch
+++ b/patches/minimatch@3.1.5.patch
@@ -1,0 +1,16 @@
+diff --git a/minimatch.js b/minimatch.js
+index 2e4a058a130dceebf83a7bd435f5d22b765ac836..c248180049c90c1c6e0136b869bc9d440f46f2a7 100644
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -7,7 +7,10 @@ var path = (function () { try { return require('path') } catch (e) {}}()) || {
+ minimatch.sep = path.sep
+ 
+ var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
+-var expand = require('brace-expansion')
++var braceExpansionModule = require('brace-expansion')
++var expand = typeof braceExpansionModule === 'function'
++  ? braceExpansionModule
++  : braceExpansionModule.expand
+ 
+ var plTypes = {
+   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   bn.js@4: 4.12.3
   bn.js@5: 5.2.5
   body-parser: 2.3.0
-  brace-expansion@1: 5.0.9
+  brace-expansion@1: 1.1.18
   brace-expansion@2: 2.1.4
   brace-expansion@5: 5.0.9
   diff: 4.0.4
@@ -3807,6 +3807,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
@@ -4085,6 +4088,9 @@ packages:
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concurrently@9.2.3:
     resolution: {integrity: sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==}
@@ -11245,6 +11251,11 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
   brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
@@ -11525,6 +11536,8 @@ snapshots:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
+
+  concat-map@0.0.1: {}
 
   concurrently@9.2.3:
     dependencies:
@@ -13358,7 +13371,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   bn.js@4: 4.12.3
   bn.js@5: 5.2.5
   body-parser: 2.3.0
-  brace-expansion@1: 1.1.18
+  brace-expansion@1: 5.0.9
   brace-expansion@2: 2.1.4
   brace-expansion@5: 5.0.9
   diff: 4.0.4
@@ -60,6 +60,11 @@ overrides:
   websocket-driver: 0.7.5
   ws@8: 8.21.0
   yaml: 2.9.0
+
+patchedDependencies:
+  minimatch@3.1.5:
+    hash: 7c8cc4137f91a36a810988f24be3fa5923f35a4c1597196e76018f82ea60ac3b
+    path: patches/minimatch@3.1.5.patch
 
 importers:
 
@@ -3807,9 +3812,6 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.18:
-    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
-
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
@@ -4088,9 +4090,6 @@ packages:
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concurrently@9.2.3:
     resolution: {integrity: sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==}
@@ -11251,11 +11250,6 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.18:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
@@ -11536,8 +11530,6 @@ snapshots:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
-
-  concat-map@0.0.1: {}
 
   concurrently@9.2.3:
     dependencies:
@@ -12441,7 +12433,7 @@ snapshots:
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=7c8cc4137f91a36a810988f24be3fa5923f35a4c1597196e76018f82ea60ac3b)
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.8.5
@@ -13369,9 +13361,9 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.9
 
-  minimatch@3.1.5:
+  minimatch@3.1.5(patch_hash=7c8cc4137f91a36a810988f24be3fa5923f35a4c1597196e76018f82ea60ac3b):
     dependencies:
-      brace-expansion: 1.1.18
+      brace-expansion: 5.0.9
 
   minimatch@5.1.9:
     dependencies:


### PR DESCRIPTION
## Summary
- PR #705 auto-merged (before #708 landed to stop this) a bump of the scoped `brace-expansion@1` override from `1.1.18` straight to `5.0.9` — a 4-major jump.
- This broke `minimatch@3.1.5` (pulled in by `fork-ts-checker-webpack-plugin@9.1.0`, which is already the latest release — this isn't fixable by bumping our devDependency), which does `var expand = require('brace-expansion')` then calls `expand(pattern, options)` directly, expecting the module to export a callable function (true for v1-v4).
- `brace-expansion@5` changed its export shape to `exports.expand = expand` (a named export). `require('brace-expansion')` now returns an object, so calling it throws `TypeError: expand is not a function`.
- Reproduced directly against the published packages before touching anything: `typeof require('brace-expansion')` is `'function'` on 1.1.18 and `'object'` on 5.0.9; calling the v5 object throws.
- This hadn't surfaced as a build failure yet because no glob pattern currently reaching this `minimatch@3` codepath contains brace (`{...}`) syntax — but it was a live landmine.

## Fix
Rather than just reverting to the vulnerable-but-compatible `1.1.18` (this branch's first commit), this patches `minimatch@3.1.5` via `pnpm patch` so it handles both export shapes:

```js
var braceExpansionModule = require('brace-expansion')
var expand = typeof braceExpansionModule === 'function'
  ? braceExpansionModule
  : braceExpansionModule.expand
```

The `brace-expansion@1` override is then set back to `5.0.9`, closing the CVE exposure for real instead of leaving it open indefinitely.

Also lands #708 (renovate.json: no automerge for scoped pnpm.overrides) so this class of bug can't recur silently.

## Test plan
- [x] Reproduced the break against the raw npm packages before fixing anything
- [x] After patching: `brace-expansion@1.1.18` no longer appears anywhere in the resolved lockfile (only the patched `5.0.9` remains)
- [x] `minimatch.braceExpand('{a,b,c}')` and glob matching with brace patterns (`*.{ts,tsx}`) work correctly
- [x] `pnpm exec turbo run build` passes across all packages