### PR TITLE
Copy patches/ dir into Docker build context before pnpm install

### DIFF
--- a/express-server/Dockerfile
+++ b/express-server/Dockerfile
@@ -13,6 +13,7 @@ ENV TURBO_TEAM=$TURBO_TEAM
 
 # Copy workspace config files first for layer caching
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml turbo.json ./
+COPY patches ./patches
 COPY common/package.json ./common/
 COPY express-server/package.json ./express-server/
 
@@ -35,6 +36,7 @@ WORKDIR /usr/src/app
 
 # Copy workspace config for production install
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches ./patches
 COPY common/package.json ./common/
 COPY express-server/package.json ./express-server/
 

--- a/next-client/Dockerfile
+++ b/next-client/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # Copy workspace config
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml turbo.json ./
+COPY patches ./patches
 COPY common/package.json ./common/
 COPY next-client/package.json ./next-client/
 

--- a/pipeline-worker/Dockerfile
+++ b/pipeline-worker/Dockerfile
@@ -13,6 +13,7 @@ ENV TURBO_TEAM=$TURBO_TEAM
 
 # Copy workspace config files first for layer caching
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml turbo.json ./
+COPY patches ./patches
 COPY common/package.json ./common/
 COPY pipeline-worker/package.json ./pipeline-worker/
 
@@ -32,6 +33,7 @@ RUN npm install -g pnpm@10
 WORKDIR /usr/src/app
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches ./patches
 COPY common/package.json ./common/
 COPY pipeline-worker/package.json ./pipeline-worker/
 


### PR DESCRIPTION
## Summary
- #709 added a pnpm patch for `minimatch@3.1.5` (`patches/minimatch@3.1.5.patch`, referenced from `package.json`'s `pnpm.patchedDependencies`).
- None of the three Dockerfiles (`next-client`, `express-server`, `pipeline-worker`) copy the `patches/` directory into the build context before running `pnpm install --frozen-lockfile`, so every Docker build since #709 merged has been failing with:
  ```
  pnpm: ENOENT: no such file or directory, open '/app/patches/minimatch@3.1.5.patch'
  ```
- This broke the staging auto-deploy triggered by #709's merge to `main` (`Deploy Development Environment` / `Deploy ... to Cloud Run` failing).

## Fix
Add `COPY patches ./patches` right after the existing workspace-config `COPY` line in every stage of every Dockerfile that runs `pnpm install`.

## Test plan
- [x] Built `next-client`'s Docker image locally end-to-end (`docker build -f next-client/Dockerfile .`) — previously failed at the `pnpm install --frozen-lockfile` step, now completes successfully through the full multi-stage build